### PR TITLE
fix pg not support function now(integer)

### DIFF
--- a/nacos-datasource-plugin-ext/nacos-postgresql-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/enums/postgresql/TrustedPostgresqlFunctionEnum.java
+++ b/nacos-datasource-plugin-ext/nacos-postgresql-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/enums/postgresql/TrustedPostgresqlFunctionEnum.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.enums.postgresql;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The TrustedSqlFunctionEnum enum class is used to enumerate and manage a list of trusted built-in SQL functions.
+ * By using this enum, you can verify whether a given SQL function is part of the trusted functions list
+ * to avoid potential SQL injection risks.
+ *
+ * @author caoyanan
+ */
+public enum TrustedPostgresqlFunctionEnum {
+
+    /**
+     * NOW().
+     */
+    NOW("NOW()", "NOW()");
+
+    private static final Map<String, TrustedPostgresqlFunctionEnum> LOOKUP_MAP = new HashMap<>();
+
+    static {
+        for (TrustedPostgresqlFunctionEnum entry : TrustedPostgresqlFunctionEnum.values()) {
+            LOOKUP_MAP.put(entry.functionName, entry);
+        }
+    }
+
+    private final String functionName;
+
+    private final String function;
+
+    TrustedPostgresqlFunctionEnum(String functionName, String function) {
+        this.functionName = functionName;
+        this.function = function;
+    }
+
+    /**
+     * Get the function name.
+     *
+     * @param functionName function name
+     * @return function
+     */
+    public static String getFunctionByName(String functionName) {
+        TrustedPostgresqlFunctionEnum entry = LOOKUP_MAP.get(functionName);
+        if (entry != null) {
+            return entry.function;
+        }
+        throw new IllegalArgumentException(String.format("Invalid function name: %s", functionName));
+    }
+}

--- a/nacos-datasource-plugin-ext/nacos-postgresql-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/ConfigInfoMapperByPostgresql.java
+++ b/nacos-datasource-plugin-ext/nacos-postgresql-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/ConfigInfoMapperByPostgresql.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.plugin.datasource.impl.postgresql;
 
 import com.alibaba.nacos.plugin.datasource.constants.DatabaseTypeConstant;
+import com.alibaba.nacos.plugin.datasource.enums.postgresql.TrustedPostgresqlFunctionEnum;
 import com.alibaba.nacos.plugin.datasource.impl.base.BaseConfigInfoMapper;
 
 /**
@@ -30,5 +31,9 @@ public class ConfigInfoMapperByPostgresql extends BaseConfigInfoMapper {
     public String getDataSource() {
         return DatabaseTypeConstant.POSTGRESQL;
     }
-    
+
+    @Override
+    public String getFunction(String functionName) {
+        return TrustedPostgresqlFunctionEnum.getFunctionByName(functionName);
+    }
 }


### PR DESCRIPTION
https://github.com/alibaba/nacos/pull/12244 引入了now转成now(3)，pg会报错
org.springframework.jdbc.BadSqlGrammarException: PreparedStatementCallback; bad SQL grammar []; nested exception is org.postgresql.util.PSQLException: ERROR: function now(integer) does not exist
  Hint: No function matches the given name and argument types. You might need to add explicit type casts.