### PR TITLE
解决pg作为数据源历史配置版本无法查看问题

### DIFF
--- a/nacos-datasource-plugin-ext/nacos-postgresql-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/HistoryConfigInfoMapperByPostgresql.java
+++ b/nacos-datasource-plugin-ext/nacos-postgresql-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/HistoryConfigInfoMapperByPostgresql.java
@@ -37,6 +37,15 @@ public class HistoryConfigInfoMapperByPostgresql extends HistoryConfigInfoMapper
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.START_TIME),
                 context.getWhereParameter(FieldConstant.LIMIT_SIZE)));
     }
+    @Override
+    public MapperResult pageFindConfigHistoryFetchRows(MapperContext context) {
+        String sql =
+                "SELECT nid,data_id,group_id,tenant_id,app_name,src_ip,src_user,op_type,gmt_create,gmt_modified FROM his_config_info "
+                        + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? ORDER BY nid DESC  LIMIT "
+                        + context.getPageSize() + " OFFSET " + context.getStartRow();
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.DATA_ID),
+                context.getWhereParameter(FieldConstant.GROUP_ID), context.getWhereParameter(FieldConstant.TENANT_ID)));
+    }
     
     @Override
     public String getDataSource() {


### PR DESCRIPTION
HistoryConfigInfoMapperByPostgresql方法下重写增加pageFindConfigHistoryFetchRows
