### PR TITLE
Fix typos in database plugin README files

### DIFF
--- a/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/README.md
+++ b/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/README.md
@@ -16,7 +16,7 @@ spring.datasource.platform=dm
 
 ### 1.2、修改dameng数据库配置文件
 
-建议dameng自带的驱动,达梦安装目录下drivers/jdbc下的驱动，否则可能会出现驱动版本不兼容的问题 （读取超长CLOB，TEXT） 替换项目中的lib/DmJdbcDriver18.jar
+建议使用dameng自带的驱动,达梦安装目录下drivers/jdbc下的驱动，否则可能会出现驱动版本不兼容的问题 （读取超长CLOB，TEXT） 替换项目中的lib/DmJdbcDriver18.jar
 
 ```xml
 
@@ -32,4 +32,4 @@ spring.datasource.platform=dm
 ### 1.3、表结构初始化
 
 在nacos数据库中执行schema/nacos-dm.sql文件，如果不是NACOS模式，需要修改schema/nacos-dm.sql文件中的模式名称
-如果表结构没用及时适配，可以使用dameng自带的数据迁移工具进行转换（dameng安装目录/tool/dts.exe 版本8.4.2.98 低版本不识别mysql自增方言）， 或者手动修改表结构
+如果表结构没有及时适配，可以使用dameng自带的数据迁移工具进行转换（dameng安装目录/tool/dts.exe 版本8.4.2.98 低版本不识别mysql自增方言）， 或者手动修改表结构

--- a/nacos-datasource-plugin-ext/nacos-oceanbase-datasource-plugin-ext/README.md
+++ b/nacos-datasource-plugin-ext/nacos-oceanbase-datasource-plugin-ext/README.md
@@ -90,7 +90,7 @@ ${nacos.home}/plugins/
 ```bash
 # 使用 Nacos 提供的 Oracle 初始化脚本
 # 注意：需要使用 Oracle 语法的 SQL 脚本
-mysql -h <oceanbase-host> -P <port> -u <username> -p < nacos-oracle.sql
+obclient -h <oceanbase-host> -P <port> -u <username> -p < nacos-oracle.sql
 ```
 
 **重要提示**：


### PR DESCRIPTION
Fixes typos in database plugin documentation:

1. nacos-dm-datasource-plugin-ext/README.md: Added missing word '使用' in section 1.2 and fixed typo '没用' to '没有' in section 1.3
2. nacos-oceanbase-datasource-plugin-ext/README.md: Changed incorrect command from 'mysql' to 'obclient' for OceanBase Oracle mode