### PR TITLE
[Custom Environment] refactor: adapt custom environment plugin to unified config model

### DIFF
--- a/nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin/src/main/java/com/alibaba/nacos/plugin/environment/NacosDbEncryptPluginService.java
+++ b/nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin/src/main/java/com/alibaba/nacos/plugin/environment/NacosDbEncryptPluginService.java
@@ -21,8 +21,10 @@ import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,15 +38,17 @@ import java.util.Set;
 public class NacosDbEncryptPluginService
         implements CustomEnvironmentPluginService, PluginConfigSpec {
 
-    private static final String DB_PWD_KEY = "db.password.0";
+    private static final String DATASOURCE_DB_PWD_KEY = "nacos.plugin.datasource.db.password.0";
 
-    private static final Set<String> PROPERTY_KEYS = Collections.singleton(DB_PWD_KEY);
+    private static final String LEGACY_DB_PWD_KEY = "db.password.0";
+
+    private static final Set<String> PROPERTY_KEYS = Collections.unmodifiableSet(
+            new LinkedHashSet<>(Arrays.asList(DATASOURCE_DB_PWD_KEY, LEGACY_DB_PWD_KEY)));
 
     @Override
     public Map<String, Object> customValue(Map<String, Object> property) {
-        String pwd = (String) property.get(DB_PWD_KEY);
-        byte[] decode = Base64.getDecoder().decode(pwd);
-        property.put(DB_PWD_KEY, new String(decode, StandardCharsets.UTF_8));
+        decodePassword(property, DATASOURCE_DB_PWD_KEY);
+        decodePassword(property, LEGACY_DB_PWD_KEY);
         return property;
     }
 
@@ -66,5 +70,14 @@ public class NacosDbEncryptPluginService
     @Override
     public List<ConfigItemDefinition> getConfigDefinitions() {
         return Collections.emptyList();
+    }
+
+    private void decodePassword(Map<String, Object> property, String key) {
+        Object password = property.get(key);
+        if (password == null) {
+            return;
+        }
+        byte[] decode = Base64.getDecoder().decode((String) password);
+        property.put(key, new String(decode, StandardCharsets.UTF_8));
     }
 }

--- a/nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin/src/main/java/com/alibaba/nacos/plugin/environment/NacosDbEncryptPluginService.java
+++ b/nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin/src/main/java/com/alibaba/nacos/plugin/environment/NacosDbEncryptPluginService.java
@@ -16,10 +16,14 @@
 
 package com.alibaba.nacos.plugin.environment;
 
+import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,23 +33,24 @@ import java.util.Set;
  * @author huangtianhui
  */
 @SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
-public class NacosDbEncryptPluginService implements CustomEnvironmentPluginService {
+public class NacosDbEncryptPluginService
+        implements CustomEnvironmentPluginService, PluginConfigSpec {
 
     private static final String DB_PWD_KEY = "db.password.0";
+
+    private static final Set<String> PROPERTY_KEYS = Collections.singleton(DB_PWD_KEY);
 
     @Override
     public Map<String, Object> customValue(Map<String, Object> property) {
         String pwd = (String) property.get(DB_PWD_KEY);
         byte[] decode = Base64.getDecoder().decode(pwd);
-        property.put(DB_PWD_KEY, new String(decode));
+        property.put(DB_PWD_KEY, new String(decode, StandardCharsets.UTF_8));
         return property;
     }
 
     @Override
     public Set<String> propertyKey() {
-        Set<String> propertyKey = new HashSet<>();
-        propertyKey.add(DB_PWD_KEY);
-        return propertyKey;
+        return PROPERTY_KEYS;
     }
 
     @Override
@@ -56,5 +61,10 @@ public class NacosDbEncryptPluginService implements CustomEnvironmentPluginServi
     @Override
     public String pluginName() {
         return "NacosDbEncryptPluginService";
+    }
+
+    @Override
+    public List<ConfigItemDefinition> getConfigDefinitions() {
+        return Collections.emptyList();
     }
 }

--- a/nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin/src/test/java/com/alibaba/nacos/plugin/environment/NacosDbEncryptPluginServiceTest.java
+++ b/nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin/src/test/java/com/alibaba/nacos/plugin/environment/NacosDbEncryptPluginServiceTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.environment;
+
+import com.alibaba.nacos.api.plugin.PluginInitializationPhase;
+import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * NacosDbEncryptPluginServiceTest.
+ *
+ * @author Nacos
+ */
+public class NacosDbEncryptPluginServiceTest {
+
+    private static final String DB_PWD_KEY = "db.password.0";
+
+    @Test
+    public void testEnvironmentPluginTypeUsesPreContextLifecycle() {
+        Assert.assertEquals(PluginInitializationPhase.PRE_CONTEXT,
+                PluginType.ENVIRONMENT.getInitializationPhase());
+    }
+
+    @Test
+    public void testZeroConfigContract() {
+        NacosDbEncryptPluginService service = new NacosDbEncryptPluginService();
+
+        Assert.assertFalse(service.isConfigurable());
+        Assert.assertTrue(service.getConfigDefinitions().isEmpty());
+        Assert.assertTrue(service.getCurrentConfig().isEmpty());
+        service.applyConfig(Collections.singletonMap("unused", "value"));
+        Assert.assertTrue(service.getCurrentConfig().isEmpty());
+    }
+
+    @Test
+    public void testPluginIdentityAndPropertyKeys() {
+        NacosDbEncryptPluginService service = new NacosDbEncryptPluginService();
+
+        Assert.assertEquals("NacosDbEncryptPluginService", service.pluginName());
+        Assert.assertEquals(Integer.valueOf(1), service.order());
+        Assert.assertEquals(Collections.singleton(DB_PWD_KEY), service.propertyKey());
+    }
+
+    @Test
+    public void testCustomValueDecodesDatabasePassword() {
+        NacosDbEncryptPluginService service = new NacosDbEncryptPluginService();
+        Map<String, Object> property = new HashMap<>();
+        property.put(DB_PWD_KEY,
+                Base64.getEncoder().encodeToString("nacos-pass".getBytes(StandardCharsets.UTF_8)));
+
+        Map<String, Object> result = service.customValue(property);
+
+        Assert.assertSame(property, result);
+        Assert.assertEquals("nacos-pass", result.get(DB_PWD_KEY));
+    }
+
+    @Test
+    public void testServiceIsDiscoverableThroughSpiWithoutManualJoin() {
+        boolean discovered = false;
+        for (CustomEnvironmentPluginService service
+                : ServiceLoader.load(CustomEnvironmentPluginService.class)) {
+            if (service instanceof NacosDbEncryptPluginService) {
+                discovered = true;
+                break;
+            }
+        }
+
+        Assert.assertTrue(discovered);
+    }
+}

--- a/nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin/src/test/java/com/alibaba/nacos/plugin/environment/NacosDbEncryptPluginServiceTest.java
+++ b/nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin/src/test/java/com/alibaba/nacos/plugin/environment/NacosDbEncryptPluginServiceTest.java
@@ -23,9 +23,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.ServiceLoader;
 
@@ -36,7 +38,9 @@ import java.util.ServiceLoader;
  */
 public class NacosDbEncryptPluginServiceTest {
 
-    private static final String DB_PWD_KEY = "db.password.0";
+    private static final String DATASOURCE_DB_PWD_KEY = "nacos.plugin.datasource.db.password.0";
+
+    private static final String LEGACY_DB_PWD_KEY = "db.password.0";
 
     @Test
     public void testEnvironmentPluginTypeUsesPreContextLifecycle() {
@@ -61,20 +65,60 @@ public class NacosDbEncryptPluginServiceTest {
 
         Assert.assertEquals("NacosDbEncryptPluginService", service.pluginName());
         Assert.assertEquals(Integer.valueOf(1), service.order());
-        Assert.assertEquals(Collections.singleton(DB_PWD_KEY), service.propertyKey());
+        Assert.assertEquals(new LinkedHashSet<>(Arrays.asList(DATASOURCE_DB_PWD_KEY, LEGACY_DB_PWD_KEY)),
+                service.propertyKey());
     }
 
     @Test
-    public void testCustomValueDecodesDatabasePassword() {
+    public void testCustomValueDecodesCanonicalDatabasePassword() {
         NacosDbEncryptPluginService service = new NacosDbEncryptPluginService();
         Map<String, Object> property = new HashMap<>();
-        property.put(DB_PWD_KEY,
-                Base64.getEncoder().encodeToString("nacos-pass".getBytes(StandardCharsets.UTF_8)));
+        property.put(DATASOURCE_DB_PWD_KEY, encode("nacos-pass"));
 
         Map<String, Object> result = service.customValue(property);
 
         Assert.assertSame(property, result);
-        Assert.assertEquals("nacos-pass", result.get(DB_PWD_KEY));
+        Assert.assertEquals("nacos-pass", result.get(DATASOURCE_DB_PWD_KEY));
+    }
+
+    @Test
+    public void testCustomValueDecodesLegacyDatabasePassword() {
+        NacosDbEncryptPluginService service = new NacosDbEncryptPluginService();
+        Map<String, Object> property = new HashMap<>();
+        property.put(LEGACY_DB_PWD_KEY, encode("legacy-pass"));
+
+        Map<String, Object> result = service.customValue(property);
+
+        Assert.assertSame(property, result);
+        Assert.assertEquals("legacy-pass", result.get(LEGACY_DB_PWD_KEY));
+    }
+
+    @Test
+    public void testCustomValueDecodesBothCanonicalAndLegacyDatabasePasswords() {
+        NacosDbEncryptPluginService service = new NacosDbEncryptPluginService();
+        Map<String, Object> property = new HashMap<>();
+        property.put(DATASOURCE_DB_PWD_KEY, encode("canonical-pass"));
+        property.put(LEGACY_DB_PWD_KEY, encode("legacy-pass"));
+
+        Map<String, Object> result = service.customValue(property);
+
+        Assert.assertSame(property, result);
+        Assert.assertEquals("canonical-pass", result.get(DATASOURCE_DB_PWD_KEY));
+        Assert.assertEquals("legacy-pass", result.get(LEGACY_DB_PWD_KEY));
+    }
+
+    @Test
+    public void testCustomValueSkipsNullDatabasePassword() {
+        NacosDbEncryptPluginService service = new NacosDbEncryptPluginService();
+        Map<String, Object> property = new HashMap<>();
+        property.put(DATASOURCE_DB_PWD_KEY, null);
+        property.put(LEGACY_DB_PWD_KEY, encode("legacy-pass"));
+
+        Map<String, Object> result = service.customValue(property);
+
+        Assert.assertSame(property, result);
+        Assert.assertNull(result.get(DATASOURCE_DB_PWD_KEY));
+        Assert.assertEquals("legacy-pass", result.get(LEGACY_DB_PWD_KEY));
     }
 
     @Test
@@ -89,5 +133,9 @@ public class NacosDbEncryptPluginServiceTest {
         }
 
         Assert.assertTrue(discovered);
+    }
+
+    private String encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/nacos-custom-environment-plugin-ext/pom.xml
+++ b/nacos-custom-environment-plugin-ext/pom.xml
@@ -16,7 +16,7 @@
     </modules>
 
     <properties>
-        <alibaba-nacos.version>3.3.0-SNAPSHOT</alibaba-nacos.version>
+        <alibaba-nacos.version>3.3.0-BETA</alibaba-nacos.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>

--- a/nacos-custom-environment-plugin-ext/pom.xml
+++ b/nacos-custom-environment-plugin-ext/pom.xml
@@ -16,11 +16,17 @@
     </modules>
 
     <properties>
+        <alibaba-nacos.version>3.3.0-SNAPSHOT</alibaba-nacos.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.alibaba.nacos</groupId>
+            <artifactId>nacos-api</artifactId>
+            <version>${alibaba-nacos.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.alibaba.nacos</groupId>
             <artifactId>nacos-custom-environment-plugin</artifactId>


### PR DESCRIPTION
## Background

Part of alibaba/nacos#15617.

This PR adapts the DB password custom environment plugin to the Nacos 3.3 unified plugin configuration/lifecycle model.

## Changes

- Update the custom environment plugin extension module to use the Nacos 3.3 plugin API.
- Keep `NacosDbEncryptPluginService` as a zero-config plugin by returning no config definitions.
- Make password decoding use `UTF-8` explicitly.
- Add tests for:
  - `ENVIRONMENT` plugin type using `PRE_CONTEXT`
  - zero-config behavior
  - plugin identity and property keys
  - Base64 database password decoding
  - SPI discovery without manual `join(...)`

## Validation

- `mvn -pl nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin -am test`
- `mvn -pl nacos-custom-environment-plugin-ext/nacos-db-password-encryption-plugin -am package`
- `git diff --check`