### PR TITLE
[Encryption] refactor: adapt encryption AES plugin to Nacos 3.3

### DIFF
--- a/nacos-encryption-plugin-ext/nacos-aes-encryption-plugin/src/test/java/com/alibaba/nacos/plugin/encryption/AesEncryptionPluginServiceTest.java
+++ b/nacos-encryption-plugin-ext/nacos-aes-encryption-plugin/src/test/java/com/alibaba/nacos/plugin/encryption/AesEncryptionPluginServiceTest.java
@@ -16,9 +16,13 @@
 
 package com.alibaba.nacos.plugin.encryption;
 
+import com.alibaba.nacos.plugin.encryption.spi.EncryptionPluginService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Optional;
 
 /**
  * AesEncryptionPluginServiceTest.
@@ -48,7 +52,7 @@ public class AesEncryptionPluginServiceTest {
         String secretKey = aesEncryptionPluginService.generateSecretKey();
         String encrypt = aesEncryptionPluginService.encrypt(secretKey, CONTENT);
         String decrypt = aesEncryptionPluginService.decrypt(secretKey, encrypt);
-        Assert.assertNotNull(decrypt);
+        Assert.assertEquals(CONTENT, decrypt);
     }
 
     @Test
@@ -60,6 +64,25 @@ public class AesEncryptionPluginServiceTest {
     @Test
     public void testNamed() {
         String named = aesEncryptionPluginService.algorithmName();
-        Assert.assertEquals(named, "aes");
+        Assert.assertEquals(AesEncryptionPluginService.AES_NAME, named);
+    }
+
+    @Test
+    public void testUnifiedDiscovery() {
+        Optional<EncryptionPluginService> service = EncryptionPluginManager.instance()
+                .findEncryptionService(AesEncryptionPluginService.AES_NAME);
+        Assert.assertTrue(service.isPresent());
+        Assert.assertTrue(service.get() instanceof AesEncryptionPluginService);
+    }
+
+    @Test
+    public void testZeroConfigContract() {
+        Assert.assertFalse(aesEncryptionPluginService.isConfigurable());
+        Assert.assertTrue(aesEncryptionPluginService.getConfigDefinitions().isEmpty());
+        Assert.assertTrue(aesEncryptionPluginService.getCurrentConfig().isEmpty());
+
+        aesEncryptionPluginService.applyConfig(Collections.singletonMap("ignored", "value"));
+
+        Assert.assertTrue(aesEncryptionPluginService.getCurrentConfig().isEmpty());
     }
 }

--- a/nacos-encryption-plugin-ext/pom.xml
+++ b/nacos-encryption-plugin-ext/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>nacos-encryption-plugin-ext</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <alibaba-nacos.version>3.3.0-SNAPSHOT</alibaba-nacos.version>
+    </properties>
+
     <modules>
         <module>nacos-aes-encryption-plugin</module>
     </modules>

--- a/nacos-encryption-plugin-ext/pom.xml
+++ b/nacos-encryption-plugin-ext/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <alibaba-nacos.version>3.3.0-SNAPSHOT</alibaba-nacos.version>
+        <alibaba-nacos.version>3.3.0-BETA</alibaba-nacos.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Background

Part of alibaba/nacos#15617.

This PR updates the AES encryption plugin family to verify compatibility with the Nacos 3.3 unified plugin management and configuration contract.

## Changes

- Override the encryption plugin family Nacos dependency to `3.3.0-SNAPSHOT`.
- Add AES plugin coverage for unified discovery through `EncryptionPluginManager`.
- Keep AES as a zero-config plugin:
  - `isConfigurable()` remains `false`
  - config definitions remain empty
  - current config remains empty after `applyConfig`
- Strengthen the decrypt test to assert the decrypted content equals the original plaintext.

## Validation

- `mvn -pl plugin/encryption -am -DskipTests install -q`
- `mvn -pl nacos-encryption-plugin-ext/nacos-aes-encryption-plugin -am test`
- `mvn -pl nacos-encryption-plugin-ext/nacos-aes-encryption-plugin -am package`
- `git diff --check`