### PR TITLE
fix(DM): 修复达梦 group/tenant capacity SQL 反引号语法错误

### DIFF
--- a/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dm/GroupCapacityMapperByDaMeng.java
+++ b/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dm/GroupCapacityMapperByDaMeng.java
@@ -53,7 +53,7 @@ public class GroupCapacityMapperByDaMeng extends AbstractMapperByDaMeng implemen
     
     @Override
     public MapperResult select(MapperContext context) {
-        String sql = "SELECT id, quota, `usage`, max_size, max_aggr_count, max_aggr_size, group_id FROM group_capacity "
+        String sql = "SELECT id, quota, usage, max_size, max_aggr_count, max_aggr_size, group_id FROM group_capacity "
                 + "WHERE group_id = ?";
         return new MapperResult(sql, Collections.singletonList(context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
@@ -70,7 +70,7 @@ public class GroupCapacityMapperByDaMeng extends AbstractMapperByDaMeng implemen
         paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
         
         String sql =
-                "INSERT INTO group_capacity (group_id, quota, `usage`, max_size, max_aggr_count, max_aggr_size,gmt_create,"
+                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size,gmt_create,"
                         + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info";
         return new MapperResult(sql, paramList);
     }
@@ -78,7 +78,7 @@ public class GroupCapacityMapperByDaMeng extends AbstractMapperByDaMeng implemen
     @Override
     public MapperResult insertIntoSelectByWhere(MapperContext context) {
         String sql =
-                "INSERT INTO group_capacity (group_id, quota, `usage`, max_size, max_aggr_count, max_aggr_size, gmt_create,"
+                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size, gmt_create,"
                         + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE group_id=? AND tenant_id = '"
                         + NamespaceUtil.getNamespaceDefaultId() + "'";
         List<Object> paramList = new ArrayList<>();
@@ -97,42 +97,42 @@ public class GroupCapacityMapperByDaMeng extends AbstractMapperByDaMeng implemen
     
     @Override
     public MapperResult incrementUsageByWhereQuotaEqualZero(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = `usage` + 1, gmt_modified = ? WHERE group_id = ? AND `usage` < ? AND quota = 0";
+        String sql = "UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ? AND usage < ? AND quota = 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID), context.getWhereParameter(FieldConstant.USAGE)));
     }
     
     @Override
     public MapperResult incrementUsageByWhereQuotaNotEqualZero(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = `usage` + 1, gmt_modified = ? WHERE group_id = ? AND `usage` < quota AND quota != 0";
+        String sql = "UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ? AND usage < quota AND quota != 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
     
     @Override
     public MapperResult incrementUsageByWhere(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = `usage` + 1, gmt_modified = ? WHERE group_id = ?";
+        String sql = "UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
     
     @Override
     public MapperResult decrementUsageByWhere(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = `usage` - 1, gmt_modified = ? WHERE group_id = ? AND `usage` > 0";
+        String sql = "UPDATE group_capacity SET usage = usage - 1, gmt_modified = ? WHERE group_id = ? AND usage > 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
     
     @Override
     public MapperResult updateUsage(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info), gmt_modified = ? WHERE group_id = ?";
+        String sql = "UPDATE group_capacity SET usage = (SELECT count(*) FROM config_info), gmt_modified = ? WHERE group_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
     
     @Override
     public MapperResult updateUsageByWhere(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE group_id=? AND "
+        String sql = "UPDATE group_capacity SET usage = (SELECT count(*) FROM config_info WHERE group_id=? AND "
                 + " tenant_id = '" + NamespaceUtil.getNamespaceDefaultId() + "'),"
                 + " gmt_modified = ? WHERE group_id= ?";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.GROUP_ID),

--- a/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dm/TenantCapacityMapperByDaMeng.java
+++ b/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dm/TenantCapacityMapperByDaMeng.java
@@ -37,44 +37,44 @@ public class TenantCapacityMapperByDaMeng extends AbstractMapperByDaMeng impleme
     
     @Override
     public MapperResult select(MapperContext context) {
-        String sql = "select id,tenant_id,quota,`usage`,max_size,max_aggr_count,max_aggr_size "
+        String sql = "select id,tenant_id,quota,usage,max_size,max_aggr_count,max_aggr_size "
                 + " from tenant_capacity where tenant_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
     public MapperResult incrementUsageWithDefaultQuotaLimit(MapperContext context) {
-        String sql = "update tenant_capacity set `usage` = `usage` + 1, gmt_modified = ? "
-                + " where tenant_id = ? and `usage` < ? and quota = 0";
+        String sql = "update tenant_capacity set usage = usage + 1, gmt_modified = ? "
+                + " where tenant_id = ? and usage < ? and quota = 0";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.TENANT_ID), context.getWhereParameter(FieldConstant.USAGE)));
     }
     
     @Override
     public MapperResult incrementUsageWithQuotaLimit(MapperContext context) {
-        String sql = "update tenant_capacity set `usage` = `usage` + 1, gmt_modified = ? "
-                + " where tenant_id = ? and `usage` < quota and quota != 0";
+        String sql = "update tenant_capacity set usage = usage + 1, gmt_modified = ? "
+                + " where tenant_id = ? and usage < quota and quota != 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
     public MapperResult incrementUsage(MapperContext context) {
-        String sql = "UPDATE tenant_capacity SET `usage` = `usage` + 1, gmt_modified = ? WHERE tenant_id = ?";
+        String sql = "UPDATE tenant_capacity SET usage = usage + 1, gmt_modified = ? WHERE tenant_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
     public MapperResult decrementUsage(MapperContext context) {
-        String sql = "UPDATE tenant_capacity SET `usage` = `usage` - 1, gmt_modified = ? WHERE tenant_id = ? AND `usage` > 0";
+        String sql = "UPDATE tenant_capacity SET usage = usage - 1, gmt_modified = ? WHERE tenant_id = ? AND usage > 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
     public MapperResult correctUsage(MapperContext context) {
-        String sql = "UPDATE tenant_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE tenant_id = ?), "
+        String sql = "UPDATE tenant_capacity SET usage = (SELECT count(*) FROM config_info WHERE tenant_id = ?), "
                         + "gmt_modified = ? WHERE tenant_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID),
                 context.getUpdateParameter(FieldConstant.GMT_MODIFIED), context.getWhereParameter(FieldConstant.TENANT_ID)));
@@ -100,7 +100,7 @@ public class TenantCapacityMapperByDaMeng extends AbstractMapperByDaMeng impleme
         paramList.add(context.getWhereParameter(FieldConstant.TENANT_ID));
         
         return new MapperResult(
-                "INSERT INTO tenant_capacity (tenant_id, quota, `usage`, max_size, max_aggr_count, max_aggr_size, "
+                "INSERT INTO tenant_capacity (tenant_id, quota, usage, max_size, max_aggr_count, max_aggr_size, "
                         + "gmt_create, gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE tenant_id=?",
                 paramList);
     }


### PR DESCRIPTION
usage 列使用了 MySQL 风格的反引号，达梦数据库无法解析，
导致 [capacityManagement] insertOrUpdateUsage 报
'line 1, column 18, nearby [`] has error'。改为不带引号的
usage，与 oracle 方言保持一致。