### PR TITLE
fix(kingbase): support config_info_gray table for nacos 2.5.x (#120)

### DIFF
--- a/nacos-datasource-plugin-ext/nacos-kingbase-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/kingbase/ConfigInfoGrayMapperByKingbase.java
+++ b/nacos-datasource-plugin-ext/nacos-kingbase-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/kingbase/ConfigInfoGrayMapperByKingbase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.impl.kingbase;
+
+import com.alibaba.nacos.plugin.datasource.constants.DatabaseTypeConstant;
+import com.alibaba.nacos.plugin.datasource.impl.base.BaseConfigInfoGrayMapper;
+
+/**
+ * The kingbase implementation of BaseConfigInfoGrayMapper.
+ *
+ * @author fanzhenyu
+ **/
+
+public class ConfigInfoGrayMapperByKingbase extends BaseConfigInfoGrayMapper {
+    
+    @Override
+    public String getDataSource() {
+        return DatabaseTypeConstant.KINGBASE;
+    }
+    
+}

--- a/nacos-datasource-plugin-ext/nacos-kingbase-datasource-plugin-ext/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.datasource.mapper.Mapper
+++ b/nacos-datasource-plugin-ext/nacos-kingbase-datasource-plugin-ext/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.datasource.mapper.Mapper
@@ -15,6 +15,7 @@
 #
 
 com.alibaba.nacos.plugin.datasource.impl.kingbase.ConfigInfoBetaMapperByKingbase
+com.alibaba.nacos.plugin.datasource.impl.kingbase.ConfigInfoGrayMapperByKingbase
 com.alibaba.nacos.plugin.datasource.impl.kingbase.ConfigInfoMapperByKingbase
 com.alibaba.nacos.plugin.datasource.impl.kingbase.ConfigInfoTagMapperByKingbase
 com.alibaba.nacos.plugin.datasource.impl.kingbase.ConfigTagsRelationMapperByKingbase

--- a/nacos-datasource-plugin-ext/nacos-kingbase-datasource-plugin-ext/src/main/resources/schema/nacos-kingbase.sql
+++ b/nacos-datasource-plugin-ext/nacos-kingbase-datasource-plugin-ext/src/main/resources/schema/nacos-kingbase.sql
@@ -54,6 +54,28 @@ CREATE TABLE `config_info_beta` (
 )  COMMENT='config_info_beta';
 
 
+CREATE TABLE `config_info_gray` (
+                                    `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
+                                    `data_id` varchar(255) NOT NULL COMMENT 'data_id',
+                                    `group_id` varchar(128) NOT NULL COMMENT 'group_id',
+                                    `content` longtext NOT NULL COMMENT 'content',
+                                    `md5` varchar(32) DEFAULT NULL COMMENT 'md5',
+                                    `src_user` text COMMENT 'src_user',
+                                    `src_ip` varchar(100) DEFAULT NULL COMMENT 'src_ip',
+                                    `gmt_create` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT 'gmt_create',
+                                    `gmt_modified` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT 'gmt_modified',
+                                    `app_name` varchar(128) DEFAULT NULL COMMENT 'app_name',
+                                    `tenant_id` varchar(128) DEFAULT '' COMMENT 'tenant_id',
+                                    `gray_name` varchar(128) NOT NULL COMMENT 'gray_name',
+                                    `gray_rule` text NOT NULL COMMENT 'gray_rule',
+                                    `encrypted_data_key` varchar(256) NOT NULL DEFAULT '' COMMENT 'encrypted_data_key',
+                                    PRIMARY KEY (`id`),
+                                    UNIQUE KEY `uk_configinfogray_datagrouptenantgray` (`data_id`,`group_id`,`tenant_id`,`gray_name`),
+                                    KEY `idx_dataid_gmt_modified` (`data_id`,`gmt_modified`),
+                                    KEY `idx_gmt_modified` (`gmt_modified`)
+)  COMMENT='config_info_gray';
+
+
 CREATE TABLE `config_info_tag` (
                                    `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
                                    `data_id` varchar(255) NOT NULL COMMENT 'data_id',


### PR DESCRIPTION
Fixes #120

为 kingbase 数据源插件补充 config_info_gray 表的适配：
1. 新增 ConfigInfoGrayMapperByKingbase（继承 BaseConfigInfoGrayMapper）
2. 在 Mapper services 中注册
3. 建表语句 nacos-kingbase.sql 增加 config_info_gray 表