### PR TITLE
feat: add SkillHub AI importer plugin

### DIFF
--- a/nacos-ai-importer-plugin-ext/README.md
+++ b/nacos-ai-importer-plugin-ext/README.md
@@ -5,3 +5,4 @@ AI resource importer plugins for Nacos.
 ## Plugins
 
 - `nacos-skills-sh-ai-importer-plugin`: imports Skill resources from the skills.sh API.
+- `nacos-skillhub-ai-importer-plugin`: imports Skill resources from a SkillHub registry (Nacos 3.2.x SPI).

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/README.md
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/README.md
@@ -1,0 +1,67 @@
+# SkillHub AI Importer Plugin
+
+Imports Skill resources from an authenticated SkillHub registry into the Nacos AI resource
+import flow.
+
+Compatible with **Nacos 3.2.x** (`AiResourceImportServiceBuilder` + `AiResourceImportSourceProvider`).
+
+## Build
+
+```bash
+mvn -pl nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin -am package
+```
+
+Copy `target/nacos-skillhub-ai-importer-plugin-*.jar` to the Nacos `plugins` directory.
+
+## Configuration
+
+```properties
+nacos.plugin.ai.importer.skills.skillhub.enabled=true
+nacos.plugin.ai.importer.skills.skillhub.endpoint=https://skillhub.example.com
+nacos.plugin.ai.importer.skills.skillhub.token=${SKILLHUB_TOKEN}
+```
+
+`namespace` is **optional**. When omitted, search defaults to **`global`**.
+
+| Search box input | Meaning |
+|---|---|
+| *(empty)* / `alpha` | search in `global` (or config default namespace) |
+| `@team-x` | list all published skills in `team-x` |
+| `@team-x alpha` | filter by keyword `alpha` in `team-x` |
+| `@team-x/alpha` | same as above |
+| `team-x--alpha` | namespace=`team-x`, keyword=`alpha` |
+
+Optional default namespace override (used when the query has no `@ns`):
+
+```properties
+nacos.plugin.ai.importer.skills.skillhub.namespace=global
+```
+
+Other optional properties:
+
+```properties
+nacos.plugin.ai.importer.skills.skillhub.source-id=skillhub
+nacos.plugin.ai.importer.skills.skillhub.display-name=SkillHub
+nacos.plugin.ai.importer.skills.skillhub.description=Import Skills from an authenticated SkillHub registry.
+nacos.plugin.ai.importer.skills.skillhub.connect-timeout-ms=3000
+nacos.plugin.ai.importer.skills.skillhub.read-timeout-ms=30000
+nacos.plugin.ai.importer.skills.skillhub.max-item-count=500
+nacos.plugin.ai.importer.skills.skillhub.max-artifact-size=10485760
+nacos.plugin.ai.importer.skills.skillhub.redirect-host-map=minio:192.168.84.4
+nacos.plugin.ai.importer.skills.skillhub.allow-http=true
+nacos.plugin.ai.importer.skills.skillhub.allow-private-network=true
+```
+
+The importer type / plugin name is `skillhub`.
+
+## Download API (iflytek/skillhub)
+
+Validation / import downloads packages using SkillHub's current routes (in order):
+
+1. `GET /api/v1/skills/{namespace}/{slug}/versions/{version}/download`
+2. `GET /api/v1/skills/{namespace}/{slug}/download`
+3. `GET /api/v1/download/{canonicalSlug}?version={version}` (ClawHub-compatible; may 302)
+4. `GET /api/v1/download?slug={canonicalSlug}&version={version}`
+
+Redirects to object storage (e.g. MinIO) are followed with optional `redirect-host-map` rewriting.
+Redirects that stay on the SkillHub API keep the Bearer token.

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/pom.xml
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/pom.xml
@@ -3,38 +3,43 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>nacos-plugin-ext</artifactId>
+        <artifactId>nacos-ai-importer-plugin-ext</artifactId>
         <groupId>com.alibaba.nacos</groupId>
         <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>nacos-ai-importer-plugin-ext</artifactId>
-    <packaging>pom</packaging>
-    <modules>
-        <module>nacos-skills-sh-ai-importer-plugin</module>
-        <module>nacos-skillhub-ai-importer-plugin</module>
-    </modules>
-
+    
+    <artifactId>nacos-skillhub-ai-importer-plugin</artifactId>
+    
     <properties>
-        <alibaba-nacos.version>3.3.0-BETA</alibaba-nacos.version>
+        <!-- Runtime target is Nacos 3.2.x (AiResourceImportServiceBuilder + SourceProvider SPI). -->
+        <alibaba-nacos.version>3.2.3</alibaba-nacos.version>
     </properties>
-
+    
     <dependencies>
         <dependency>
             <groupId>com.alibaba.nacos</groupId>
             <artifactId>nacos-ai-plugin</artifactId>
             <version>${alibaba-nacos.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.alibaba.nacos</groupId>
             <artifactId>nacos-api</artifactId>
             <version>${alibaba-nacos.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.alibaba.nacos</groupId>
             <artifactId>nacos-common</artifactId>
             <version>${alibaba-nacos.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.21.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportConfig.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportConfig.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Runtime configuration resolved from {@link AiResourceImportSource}.
+ *
+ * @author nacos
+ */
+public class SkillHubImportConfig {
+    
+    private final String endpoint;
+    
+    private final String token;
+    
+    private final String namespace;
+    
+    private final boolean allowHttp;
+    
+    private final boolean allowPrivateNetwork;
+    
+    private final int connectTimeoutMillis;
+    
+    private final int readTimeoutMillis;
+    
+    private final int maxItemCount;
+    
+    private final long maxArtifactSize;
+    
+    private final Map<String, String> redirectHostMap;
+    
+    public SkillHubImportConfig(AiResourceImportSource source) {
+        Map<String, String> properties = source.getProperties() == null
+                ? Collections.<String, String>emptyMap()
+                : source.getProperties();
+        this.endpoint = source.getEndpoint();
+        this.token = firstNonBlank(properties.get(SkillHubImportSourceProvider.PROPERTY_TOKEN),
+                properties.get("api-token"), properties.get("auth-token"));
+        this.namespace = SkillHubSlug.normalizeNamespace(
+                firstNonBlank(properties.get(SkillHubImportSourceProvider.PROPERTY_NAMESPACE),
+                        properties.get("namespaceSlug")));
+        this.allowHttp = Boolean.parseBoolean(
+                firstNonBlank(properties.get(SkillHubImportSourceProvider.PROPERTY_ALLOW_HTTP),
+                        properties.get("allowHttp"), "false"));
+        this.allowPrivateNetwork = Boolean.parseBoolean(firstNonBlank(
+                properties.get(SkillHubImportSourceProvider.PROPERTY_ALLOW_PRIVATE_NETWORK),
+                properties.get("allowPrivateNetwork"), "false"));
+        this.connectTimeoutMillis = source.getConnectTimeoutMillis() > 0
+                ? source.getConnectTimeoutMillis() : 3000;
+        this.readTimeoutMillis =
+                source.getReadTimeoutMillis() > 0 ? source.getReadTimeoutMillis() : 30000;
+        this.maxItemCount = source.getMaxItemCount() > 0 ? source.getMaxItemCount() : 500;
+        this.maxArtifactSize =
+                source.getMaxArtifactSize() > 0 ? source.getMaxArtifactSize() : 10L * 1024L * 1024L;
+        this.redirectHostMap = parseRedirectHostMap(
+                firstNonBlank(properties.get(SkillHubImportSourceProvider.PROPERTY_REDIRECT_HOST_MAP),
+                        properties.get("redirectHostMap"), ""));
+    }
+    
+    public SkillHubImportConfig(String endpoint, String token, String namespace, boolean allowHttp,
+            boolean allowPrivateNetwork, int connectTimeoutMillis, int readTimeoutMillis,
+            int maxItemCount, long maxArtifactSize, Map<String, String> redirectHostMap) {
+        this.endpoint = endpoint;
+        this.token = token;
+        this.namespace = SkillHubSlug.normalizeNamespace(namespace);
+        this.allowHttp = allowHttp;
+        this.allowPrivateNetwork = allowPrivateNetwork;
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        this.readTimeoutMillis = readTimeoutMillis;
+        this.maxItemCount = maxItemCount;
+        this.maxArtifactSize = maxArtifactSize;
+        this.redirectHostMap = redirectHostMap == null
+                ? Collections.<String, String>emptyMap()
+                : new LinkedHashMap<String, String>(redirectHostMap);
+    }
+    
+    static Map<String, String> parseRedirectHostMap(String raw) {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        if (StringUtils.isBlank(raw)) {
+            return result;
+        }
+        String[] parts = raw.split(",");
+        for (String part : parts) {
+            String piece = part.trim();
+            if (StringUtils.isBlank(piece) || !piece.contains(":")) {
+                continue;
+            }
+            int index = piece.indexOf(':');
+            String src = piece.substring(0, index).trim();
+            String dst = piece.substring(index + 1).trim();
+            if (StringUtils.isNotBlank(src) && StringUtils.isNotBlank(dst)) {
+                result.put(src, dst);
+            }
+        }
+        return result;
+    }
+    
+    private static String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String each : values) {
+            if (StringUtils.isNotBlank(each)) {
+                return each.trim();
+            }
+        }
+        return null;
+    }
+    
+    public String getEndpoint() {
+        return endpoint;
+    }
+    
+    public String getToken() {
+        return token;
+    }
+    
+    public String getNamespace() {
+        return namespace;
+    }
+    
+    public boolean isAllowHttp() {
+        return allowHttp;
+    }
+    
+    public boolean isAllowPrivateNetwork() {
+        return allowPrivateNetwork;
+    }
+    
+    public int getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+    
+    public int getReadTimeoutMillis() {
+        return readTimeoutMillis;
+    }
+    
+    public int getMaxItemCount() {
+        return maxItemCount;
+    }
+    
+    public long getMaxArtifactSize() {
+        return maxArtifactSize;
+    }
+    
+    public Map<String, String> getRedirectHostMap() {
+        return new LinkedHashMap<String, String>(redirectHostMap);
+    }
+}

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportService.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportService.java
@@ -1,0 +1,880 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.AiResourceImportConstants;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidate;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidatePage;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportContext;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import com.alibaba.nacos.plugin.ai.importer.skillhub.http.DefaultSkillHubHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.skillhub.http.SkillHubHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.skillhub.http.SkillHubHttpResponse;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Importer for SkillHub registry APIs (Nacos 3.2.x SPI).
+ *
+ * @author nacos
+ */
+public class SkillHubImportService implements AiResourceImportService {
+    
+    public static final String RESOURCE_TYPE_SKILL = AiResourceImportConstants.RESOURCE_TYPE_SKILL;
+    
+    private static final String METADATA_SOURCE = "source";
+    
+    private static final String METADATA_NAMESPACE = "namespace";
+    
+    private static final String METADATA_SKILL_ID = "skillId";
+    
+    private static final String METADATA_VERSION = "version";
+    
+    private static final String METADATA_CANONICAL_SLUG = "canonicalSlug";
+    
+    private static final String METADATA_CHECKSUM = "checksum";
+    
+    private static final String OPTION_NAMESPACE = "namespace";
+    
+    private static final String DEFAULT_NAMESPACE = "global";
+    
+    private static final String SKILL_MARKDOWN_FILE = "SKILL.md";
+    
+    private static final int DEFAULT_LIMIT = 100;
+    
+    private static final String SOURCE_VALUE = "skillhub";
+    
+    private final SkillHubHttpClient httpClient;
+    
+    public SkillHubImportService() {
+        this(new DefaultSkillHubHttpClient());
+    }
+    
+    SkillHubImportService(SkillHubHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+    
+    @Override
+    public String importerType() {
+        return SkillHubImportServiceBuilder.IMPORTER_TYPE;
+    }
+    
+    @Override
+    public Set<String> supportedResourceTypes() {
+        return Collections.singleton(RESOURCE_TYPE_SKILL);
+    }
+    
+    @Override
+    public AiResourceImportCandidatePage search(AiResourceImportContext context) throws NacosException {
+        try {
+            SkillHubImportConfig config = resolveConfig(context);
+            SkillHubSlug.NamespaceQuery namespaceQuery = resolveSearchNamespaceQuery(context, config);
+            String apiRoot = resolveApiRoot(config);
+            int resultLimit = resolveLimit(context.getLimit(), config);
+            List<SkillHubRemoteSkill> skills = listPublishedSkills(config, apiRoot,
+                    namespaceQuery.getNamespace(), resultLimit);
+            List<AiResourceImportCandidate> candidates = toCandidates(namespaceQuery.getNamespace(),
+                    skills, namespaceQuery.getKeyword(), resultLimit);
+            AiResourceImportCandidatePage result = new AiResourceImportCandidatePage();
+            result.setItems(candidates);
+            result.setHasMore(false);
+            result.setNextCursor(null);
+            return result;
+        } catch (NacosException e) {
+            throw e;
+        } catch (Exception e) {
+            throw dataAccess("Search SkillHub source failed: " + e.getMessage(), e);
+        }
+    }
+    
+    @Override
+    public AiResourceImportArtifact fetch(AiResourceImportContext context, AiResourceImportItem item)
+            throws NacosException {
+        try {
+            SkillHubImportConfig config = resolveConfig(context);
+            String apiRoot = resolveApiRoot(config);
+            SkillHubRemoteSkill skill = resolveSkillRef(context, config, item);
+            byte[] zipBytes = downloadZip(config, apiRoot, skill);
+            checkDownloadedSize(config, zipBytes.length);
+            validateSkillZip(zipBytes);
+            AiResourceImportArtifact result = new AiResourceImportArtifact();
+            result.setResourceType(RESOURCE_TYPE_SKILL);
+            result.setExternalId(skill.getCanonicalSlug());
+            result.setName(skill.getLocalName());
+            result.setPayloadKind(AiResourceImportPayloadKind.SKILL_ZIP);
+            result.setPayload(zipBytes);
+            String checksum = sha256Hex(zipBytes);
+            result.setChecksum(checksum);
+            result.setSourceMetadata(buildArtifactMetadata(skill, checksum));
+            return result;
+        } catch (NacosException e) {
+            throw e;
+        } catch (Exception e) {
+            throw dataAccess("Fetch SkillHub artifact failed: " + e.getMessage(), e);
+        }
+    }
+    
+    private SkillHubImportConfig resolveConfig(AiResourceImportContext context) throws NacosException {
+        AiResourceImportSource source = requireSource(context);
+        SkillHubImportConfig config = new SkillHubImportConfig(source);
+        if (StringUtils.isBlank(config.getEndpoint())) {
+            throw invalid("SkillHub import source endpoint must not be empty.");
+        }
+        if (StringUtils.isBlank(config.getToken())) {
+            throw invalid("SkillHub import source token must not be empty.");
+        }
+        return config;
+    }
+    
+    /**
+     * Resolve namespace for search: options.namespace &gt; {@code @ns} query &gt; config default &gt; global.
+     */
+    private SkillHubSlug.NamespaceQuery resolveSearchNamespaceQuery(AiResourceImportContext context,
+            SkillHubImportConfig config) throws NacosException {
+        String optionNamespace = optionValue(context, OPTION_NAMESPACE);
+        String defaultNamespace = StringUtils.isNotBlank(config.getNamespace())
+                ? config.getNamespace() : DEFAULT_NAMESPACE;
+        SkillHubSlug.NamespaceQuery parsed =
+                SkillHubSlug.parseSearchQuery(context.getQuery(), defaultNamespace);
+        String namespace = StringUtils.isNotBlank(optionNamespace)
+                ? SkillHubSlug.normalizeNamespace(optionNamespace) : parsed.getNamespace();
+        if (StringUtils.isBlank(namespace)) {
+            namespace = DEFAULT_NAMESPACE;
+        }
+        String keyword = StringUtils.isNotBlank(optionNamespace) ? nullToEmpty(context.getQuery()).trim()
+                : parsed.getKeyword();
+        if (StringUtils.isNotBlank(optionNamespace) && keyword.startsWith("@")) {
+            // options already selected ns; strip a redundant @prefix from free-text query.
+            SkillHubSlug.NamespaceQuery again = SkillHubSlug.parseSearchQuery(keyword, namespace);
+            keyword = again.getKeyword();
+            if (StringUtils.isNotBlank(again.getNamespace())) {
+                namespace = again.getNamespace();
+            }
+        }
+        return new SkillHubSlug.NamespaceQuery(namespace, keyword);
+    }
+    
+    private AiResourceImportSource requireSource(AiResourceImportContext context) throws NacosException {
+        if (context == null || context.getSource() == null) {
+            throw invalid("SkillHub import source must not be null.");
+        }
+        return context.getSource();
+    }
+    
+    private List<SkillHubRemoteSkill> listPublishedSkills(SkillHubImportConfig config, String apiRoot,
+            String namespace, int limit) throws Exception {
+        String ns = SkillHubSlug.normalizeNamespace(namespace);
+        List<ListStrategy> strategies = new ArrayList<ListStrategy>();
+        strategies.add(new ListStrategy(apiRoot + "/api/v1/skills",
+                "namespaceSlug=" + encodeQueryValue(ns) + "&page=0&size=" + limit + "&limit=" + limit));
+        strategies.add(new ListStrategy(apiRoot + "/api/v1/skills",
+                "namespace=" + encodeQueryValue(ns) + "&page=0&size=" + limit + "&limit=" + limit));
+        strategies.add(new ListStrategy(apiRoot + "/api/web/skills",
+                "namespace=" + encodeQueryValue(ns) + "&q=&page=0&size=" + limit));
+        strategies.add(new ListStrategy(apiRoot + "/api/v1/search",
+                "q=" + encodeQueryValue("@" + ns) + "&page=1&limit=" + limit));
+        if ("global".equals(ns)) {
+            strategies.add(0, new ListStrategy(apiRoot + "/api/v1/search",
+                    "q=&page=1&limit=" + limit));
+        }
+        
+        int authFailures = 0;
+        int attempts = 0;
+        Map<String, SkillHubRemoteSkill> byName = new LinkedHashMap<String, SkillHubRemoteSkill>();
+        for (ListStrategy strategy : strategies) {
+            attempts++;
+            String url = strategy.path + "?" + strategy.query;
+            SkillHubHttpResponse response = httpClient.get(config, url, true, null, true);
+            int status = response.getStatusCode();
+            if (status == 401 || status == 403) {
+                authFailures++;
+                continue;
+            }
+            if (!response.isSuccess()) {
+                continue;
+            }
+            List<SkillHubRemoteSkill> parsed = parseSkillList(ns, response.getBody());
+            for (SkillHubRemoteSkill skill : parsed) {
+                byName.put(skill.getLocalName(), skill);
+            }
+            if (!byName.isEmpty()) {
+                return new ArrayList<SkillHubRemoteSkill>(byName.values());
+            }
+        }
+        if (byName.isEmpty() && authFailures == attempts && attempts > 0) {
+            throw invalid("SkillHub list authentication failed for namespace: " + ns);
+        }
+        return new ArrayList<SkillHubRemoteSkill>(byName.values());
+    }
+    
+    private List<SkillHubRemoteSkill> parseSkillList(String namespace, byte[] body) throws Exception {
+        if (body == null || body.length == 0) {
+            return Collections.emptyList();
+        }
+        JsonNode root = JacksonUtils.toObj(new String(body, StandardCharsets.UTF_8), JsonNode.class);
+        List<JsonNode> items = extractItemList(root);
+        List<SkillHubRemoteSkill> result = new ArrayList<SkillHubRemoteSkill>();
+        for (JsonNode item : items) {
+            if (item == null || !item.isObject()) {
+                continue;
+            }
+            SkillHubRemoteSkill parsed = parseRemoteSkill(namespace, item);
+            if (parsed != null) {
+                result.add(parsed);
+            }
+        }
+        return result;
+    }
+    
+    private List<JsonNode> extractItemList(JsonNode root) {
+        if (root == null || root.isNull()) {
+            return Collections.emptyList();
+        }
+        if (root.isArray()) {
+            List<JsonNode> result = new ArrayList<JsonNode>();
+            for (JsonNode each : root) {
+                result.add(each);
+            }
+            return result;
+        }
+        if (!root.isObject()) {
+            return Collections.emptyList();
+        }
+        for (String key : new String[] {"results", "items", "content", "records", "list"}) {
+            JsonNode val = root.get(key);
+            if (val != null && val.isArray()) {
+                List<JsonNode> result = new ArrayList<JsonNode>();
+                for (JsonNode each : val) {
+                    result.add(each);
+                }
+                return result;
+            }
+        }
+        JsonNode data = root.get("data");
+        if (data != null && data.isArray()) {
+            List<JsonNode> result = new ArrayList<JsonNode>();
+            for (JsonNode each : data) {
+                result.add(each);
+            }
+            return result;
+        }
+        if (data != null && data.isObject()) {
+            for (String key : new String[] {"results", "items", "content", "records", "list"}) {
+                JsonNode val = data.get(key);
+                if (val != null && val.isArray()) {
+                    List<JsonNode> result = new ArrayList<JsonNode>();
+                    for (JsonNode each : val) {
+                        result.add(each);
+                    }
+                    return result;
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+    
+    private SkillHubRemoteSkill parseRemoteSkill(String namespace, JsonNode item) {
+        String rawSlug = firstText(item, "slug", "skillSlug", "name");
+        if (StringUtils.isBlank(rawSlug)) {
+            return null;
+        }
+        String explicitNsRaw = firstText(item, "namespace", "namespaceSlug");
+        String explicitNs = StringUtils.isBlank(explicitNsRaw) ? ""
+                : SkillHubSlug.normalizeNamespace(explicitNsRaw);
+        String canonical;
+        String localName;
+        if (rawSlug.contains("--")) {
+            canonical = rawSlug;
+            if (!SkillHubSlug.skillBelongsToNamespace(namespace, canonical)) {
+                return null;
+            }
+            try {
+                localName = SkillHubSlug.localSkillNameFromCanonical(namespace, canonical);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        } else {
+            if (StringUtils.isNotBlank(explicitNs)) {
+                if (!explicitNs.equals(namespace)) {
+                    return null;
+                }
+            } else if (!"global".equals(namespace)) {
+                return null;
+            }
+            localName = rawSlug;
+            canonical = SkillHubSlug.hubCanonicalSlug(namespace, localName);
+        }
+        String version = extractVersion(item);
+        if (StringUtils.isBlank(version)) {
+            return null;
+        }
+        String description = textOrEmpty(item.get("description"));
+        return new SkillHubRemoteSkill(canonical, localName, version, description);
+    }
+    
+    private String extractVersion(JsonNode item) {
+        JsonNode published = item.get("publishedVersion");
+        if (published != null && published.isObject()) {
+            String version = textOrEmpty(published.get("version"));
+            if (StringUtils.isNotBlank(version)) {
+                return version;
+            }
+        } else if (published != null && published.isTextual()) {
+            String version = published.asText().trim();
+            if (StringUtils.isNotBlank(version)) {
+                return version;
+            }
+        }
+        for (String key : new String[] {"latestVersion", "latest_version"}) {
+            JsonNode latest = item.get(key);
+            if (latest != null && latest.isObject()) {
+                String version = textOrEmpty(latest.get("version"));
+                if (StringUtils.isNotBlank(version)) {
+                    return version;
+                }
+            } else if (latest != null && latest.isTextual()) {
+                String version = latest.asText().trim();
+                if (StringUtils.isNotBlank(version)) {
+                    return version;
+                }
+            }
+        }
+        return textOrEmpty(item.get("version"));
+    }
+    
+    private List<AiResourceImportCandidate> toCandidates(String namespace,
+            List<SkillHubRemoteSkill> skills, String query, int limit) {
+        if (skills == null || skills.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String normalizedQuery = query == null ? "" : query.trim().toLowerCase(Locale.ENGLISH);
+        List<AiResourceImportCandidate> result = new ArrayList<AiResourceImportCandidate>();
+        for (SkillHubRemoteSkill skill : skills) {
+            if (skill == null) {
+                continue;
+            }
+            if (StringUtils.isNotBlank(normalizedQuery) && !matchesQuery(skill, normalizedQuery)) {
+                continue;
+            }
+            AiResourceImportCandidate candidate = new AiResourceImportCandidate();
+            candidate.setResourceType(RESOURCE_TYPE_SKILL);
+            candidate.setExternalId(skill.getCanonicalSlug());
+            candidate.setName(skill.getLocalName());
+            // Console matches validate results by `${externalId}__${version}`; keep in sync.
+            candidate.setVersion(skill.getVersion());
+            candidate.setDescription(skill.getDescription());
+            candidate.setMetadata(buildCandidateMetadata(namespace, skill));
+            result.add(candidate);
+            if (result.size() >= limit) {
+                break;
+            }
+        }
+        return result;
+    }
+    
+    private boolean matchesQuery(SkillHubRemoteSkill skill, String normalizedQuery) {
+        return containsIgnoreCase(skill.getLocalName(), normalizedQuery)
+                || containsIgnoreCase(skill.getDescription(), normalizedQuery)
+                || containsIgnoreCase(skill.getCanonicalSlug(), normalizedQuery);
+    }
+    
+    private boolean containsIgnoreCase(String value, String needle) {
+        if (StringUtils.isBlank(value)) {
+            return false;
+        }
+        return value.toLowerCase(Locale.ENGLISH).contains(needle);
+    }
+    
+    private SkillHubRemoteSkill resolveSkillRef(AiResourceImportContext context,
+            SkillHubImportConfig config, AiResourceImportItem item) throws NacosException {
+        if (item == null) {
+            throw invalid("SkillHub import item must not be null.");
+        }
+        Map<String, String> metadata = item.getMetadata();
+        String namespace = metadata == null ? null : metadata.get(METADATA_NAMESPACE);
+        if (StringUtils.isBlank(namespace)) {
+            namespace = optionValue(context, OPTION_NAMESPACE);
+        }
+        if (StringUtils.isBlank(namespace)) {
+            namespace = config.getNamespace();
+        }
+        String version = metadata == null ? null : metadata.get(METADATA_VERSION);
+        String canonical = metadata == null ? null : metadata.get(METADATA_CANONICAL_SLUG);
+        String skillId = metadata == null ? null : metadata.get(METADATA_SKILL_ID);
+        if (StringUtils.isBlank(canonical)) {
+            canonical = StringUtils.isNotBlank(item.getExternalId()) ? item.getExternalId() : item.getName();
+        }
+        if (StringUtils.isBlank(canonical)) {
+            throw invalid("SkillHub import item must include canonical slug or external id.");
+        }
+        if (StringUtils.isBlank(namespace) && canonical.contains("--")) {
+            namespace = SkillHubSlug.normalizeNamespace(canonical.split("--", 2)[0]);
+        }
+        if (StringUtils.isBlank(namespace)) {
+            namespace = "global";
+        } else {
+            namespace = SkillHubSlug.normalizeNamespace(namespace);
+        }
+        if (StringUtils.isBlank(skillId)) {
+            try {
+                skillId = SkillHubSlug.localSkillNameFromCanonical(namespace, canonical);
+            } catch (IllegalArgumentException e) {
+                skillId = item.getName();
+            }
+        }
+        if (StringUtils.isBlank(version)) {
+            throw invalid("SkillHub import item must include version metadata.");
+        }
+        if (StringUtils.isBlank(skillId)) {
+            skillId = canonical;
+        }
+        // Keep canonical consistent with the resolved namespace for non-global skills.
+        if (!"global".equals(namespace) && !canonical.contains("--")) {
+            canonical = SkillHubSlug.hubCanonicalSlug(namespace, skillId);
+        }
+        return new SkillHubRemoteSkill(canonical.trim(), skillId.trim(), version.trim(), "",
+                namespace);
+    }
+    
+    private byte[] downloadZip(SkillHubImportConfig config, String apiRoot, SkillHubRemoteSkill skill)
+            throws Exception {
+        List<String> urls = buildDownloadUrls(apiRoot, skill);
+        Exception lastError = null;
+        for (String url : urls) {
+            try {
+                return fetchZipFollowingRedirects(config, apiRoot, url, null, true, 0);
+            } catch (Exception e) {
+                lastError = e;
+            }
+        }
+        if (lastError instanceof NacosException) {
+            throw (NacosException) lastError;
+        }
+        if (lastError != null) {
+            throw dataAccess("SkillHub download failed: " + lastError.getMessage(), lastError);
+        }
+        throw invalid("SkillHub download failed for " + skill.getCanonicalSlug());
+    }
+    
+    /**
+     * Build download URL candidates for iflytek/skillhub.
+     *
+     * <p>Primary routes are {@code GET /api/v1/skills/{ns}/{slug}/[versions/{ver}/]download}.
+     * ClawHub-compatible fallbacks use {@code GET /api/v1/download/{canonicalSlug}?version=}
+     * (and the query form), which redirect to the skills download path.
+     */
+    private List<String> buildDownloadUrls(String apiRoot, SkillHubRemoteSkill skill) throws Exception {
+        String slug = skill.getCanonicalSlug();
+        String version = skill.getVersion();
+        String namespace;
+        String shortName;
+        if (slug.contains("--")) {
+            String[] parts = slug.split("--", 2);
+            namespace = parts[0];
+            shortName = parts[1];
+        } else {
+            namespace = StringUtils.isNotBlank(skill.getNamespace()) ? skill.getNamespace() : "global";
+            shortName = slug;
+        }
+        String nsSeg = encodePathSegment(namespace);
+        String nameSeg = encodePathSegment(shortName);
+        String versionSeg = encodePathSegment(version);
+        String canonicalSeg = encodePathSegment(slug);
+        String versionQuery = encodeQueryValue(version);
+        
+        List<String> urls = new ArrayList<String>();
+        // Prefer the concrete versioned package first.
+        urls.add(apiRoot + "/api/v1/skills/" + nsSeg + "/" + nameSeg + "/versions/" + versionSeg
+                + "/download");
+        urls.add(apiRoot + "/api/v1/skills/" + nsSeg + "/" + nameSeg + "/download");
+        // ClawHub-compatible download entrypoints (302 -> skills download path).
+        urls.add(apiRoot + "/api/v1/download/" + canonicalSeg + "?version=" + versionQuery);
+        urls.add(apiRoot + "/api/v1/download?slug=" + encodeQueryValue(slug) + "&version="
+                + versionQuery);
+        return urls;
+    }
+    
+    private byte[] fetchZipFollowingRedirects(SkillHubImportConfig config, String apiRoot, String url,
+            String hostHeader, boolean withAuth, int depth) throws Exception {
+        if (depth > 5) {
+            throw new IllegalStateException("SkillHub download redirect limit exceeded for " + url);
+        }
+        SkillHubHttpResponse response = httpClient.get(config, url, false, hostHeader, withAuth);
+        if (response.isRedirect()) {
+            String location = response.getLocation();
+            if (StringUtils.isBlank(location)) {
+                throw new IllegalStateException(
+                        "HTTP " + response.getStatusCode() + " without Location for " + url);
+            }
+            URI absolute = URI.create(url).resolve(location.trim());
+            RedirectRewrite rewrite = rewriteRedirectLocation(config, absolute.toString());
+            boolean nextWithAuth = isSkillHubApiUrl(apiRoot, rewrite.getFetchUrl());
+            return fetchZipFollowingRedirects(config, apiRoot, rewrite.getFetchUrl(),
+                    rewrite.getHostHeader(), nextWithAuth, depth + 1);
+        }
+        if (!response.isSuccess()) {
+            throw new IllegalStateException(
+                    "HTTP " + response.getStatusCode() + " when fetching " + url);
+        }
+        byte[] zip = zipBytesFromResponse(response.getBody());
+        if (zip == null) {
+            throw new IllegalStateException("SkillHub download response is not a zip: " + url);
+        }
+        return zip;
+    }
+    
+    private boolean isSkillHubApiUrl(String apiRoot, String fetchUrl) {
+        if (StringUtils.isBlank(fetchUrl)) {
+            return false;
+        }
+        try {
+            URI api = URI.create(apiRoot);
+            URI target = URI.create(fetchUrl);
+            if (StringUtils.isBlank(target.getHost())) {
+                return true;
+            }
+            if (StringUtils.isBlank(api.getHost()) || !api.getHost().equalsIgnoreCase(target.getHost())) {
+                return false;
+            }
+            int apiPort = api.getPort() >= 0 ? api.getPort() : defaultPort(api.getScheme());
+            int targetPort = target.getPort() >= 0 ? target.getPort() : defaultPort(target.getScheme());
+            if (apiPort != targetPort) {
+                return false;
+            }
+            String path = target.getPath() == null ? "" : target.getPath();
+            return path.startsWith("/api/");
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+    
+    private int defaultPort(String scheme) {
+        if ("https".equalsIgnoreCase(scheme)) {
+            return 443;
+        }
+        if ("http".equalsIgnoreCase(scheme)) {
+            return 80;
+        }
+        return -1;
+    }
+    
+    RedirectRewrite rewriteRedirectLocation(SkillHubImportConfig config, String location)
+            throws NacosException {
+        if (StringUtils.isBlank(location)) {
+            return new RedirectRewrite(location, null);
+        }
+        URI parsed;
+        try {
+            parsed = URI.create(location.trim());
+        } catch (IllegalArgumentException e) {
+            return new RedirectRewrite(location, null);
+        }
+        String hostname = parsed.getHost();
+        if (StringUtils.isBlank(hostname)) {
+            return new RedirectRewrite(location, null);
+        }
+        Map<String, String> mapping = config.getRedirectHostMap();
+        String target = mapping.get(hostname);
+        if (target == null && "minio".equals(hostname)) {
+            URI apiBase = URI.create(trimTrailingSlash(config.getEndpoint()));
+            if (StringUtils.isNotBlank(apiBase.getHost())) {
+                target = apiBase.getHost();
+            }
+        }
+        if (StringUtils.isBlank(target) || target.equals(hostname)) {
+            return new RedirectRewrite(location, null);
+        }
+        String originalNetloc = parsed.getPort() >= 0 ? hostname + ":" + parsed.getPort() : hostname;
+        String newNetloc = parsed.getPort() >= 0 ? target + ":" + parsed.getPort() : target;
+        try {
+            String newUrl = new URI(parsed.getScheme(), newNetloc, parsed.getPath(), parsed.getQuery(),
+                    parsed.getFragment()).toString();
+            return new RedirectRewrite(newUrl, originalNetloc);
+        } catch (java.net.URISyntaxException e) {
+            return new RedirectRewrite(location, null);
+        }
+    }
+    
+    private byte[] zipBytesFromResponse(byte[] body) {
+        if (body == null || body.length < 2) {
+            return null;
+        }
+        if (body[0] == 'P' && body[1] == 'K') {
+            return body;
+        }
+        if (body[0] != '{' && body[0] != '[') {
+            return body;
+        }
+        return null;
+    }
+    
+    private void validateSkillZip(byte[] zipBytes) throws Exception {
+        boolean hasSkillMarkdown = false;
+        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(zipBytes),
+                StandardCharsets.UTF_8)) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                String name = normalizeZipEntryName(entry.getName());
+                if (StringUtils.isBlank(name)) {
+                    continue;
+                }
+                validatePathSafety(name);
+                String fileName = name.contains("/") ? name.substring(name.lastIndexOf('/') + 1) : name;
+                if (SKILL_MARKDOWN_FILE.equalsIgnoreCase(fileName)) {
+                    hasSkillMarkdown = true;
+                }
+            }
+        }
+        if (!hasSkillMarkdown) {
+            throw invalid("SkillHub zip must contain SKILL.md.");
+        }
+    }
+    
+    private String normalizeZipEntryName(String path) {
+        if (StringUtils.isBlank(path)) {
+            return null;
+        }
+        String result = path.trim().replace('\\', '/');
+        while (result.startsWith("./")) {
+            result = result.substring(2);
+        }
+        return result;
+    }
+    
+    private void validatePathSafety(String path) throws NacosException {
+        if (StringUtils.isBlank(path) || path.startsWith("/") || path.contains("\\")) {
+            throw invalid("SkillHub zip path is invalid: " + path);
+        }
+        String[] segments = path.split("/");
+        for (String segment : segments) {
+            if (StringUtils.isBlank(segment) || ".".equals(segment) || "..".equals(segment)) {
+                throw invalid("SkillHub zip path is invalid: " + path);
+            }
+        }
+    }
+    
+    private void checkDownloadedSize(SkillHubImportConfig config, long totalSize) throws NacosException {
+        if (config.getMaxArtifactSize() > 0 && totalSize > config.getMaxArtifactSize()) {
+            throw invalid("SkillHub artifact size exceeds source limit.");
+        }
+    }
+    
+    private Map<String, String> buildCandidateMetadata(String namespace, SkillHubRemoteSkill skill) {
+        Map<String, String> metadata = new LinkedHashMap<String, String>();
+        metadata.put(METADATA_SOURCE, SOURCE_VALUE);
+        metadata.put(METADATA_NAMESPACE, namespace);
+        metadata.put(METADATA_SKILL_ID, skill.getLocalName());
+        metadata.put(METADATA_VERSION, skill.getVersion());
+        metadata.put(METADATA_CANONICAL_SLUG, skill.getCanonicalSlug());
+        return metadata;
+    }
+    
+    private Map<String, String> buildArtifactMetadata(SkillHubRemoteSkill skill, String checksum) {
+        Map<String, String> metadata = buildCandidateMetadata(
+                StringUtils.isBlank(skill.getNamespace()) ? "global" : skill.getNamespace(), skill);
+        if (StringUtils.isNotBlank(checksum)) {
+            metadata.put(METADATA_CHECKSUM, checksum);
+        }
+        return metadata;
+    }
+    
+    private String optionValue(AiResourceImportContext context, String key) {
+        if (context == null || context.getOptions() == null || StringUtils.isBlank(key)) {
+            return null;
+        }
+        return context.getOptions().get(key);
+    }
+    
+    private int resolveLimit(int limit, SkillHubImportConfig config) {
+        if (limit <= 0) {
+            return Math.min(DEFAULT_LIMIT, config.getMaxItemCount());
+        }
+        return Math.min(limit, config.getMaxItemCount());
+    }
+    
+    private String resolveApiRoot(SkillHubImportConfig config) throws NacosException {
+        return trimTrailingSlash(config.getEndpoint());
+    }
+    
+    private String encodePathSegment(String value) throws UnsupportedEncodingException {
+        return URLEncoder.encode(nullToEmpty(value), StandardCharsets.UTF_8.name()).replace("+", "%20");
+    }
+    
+    private String encodeQueryValue(String value) throws UnsupportedEncodingException {
+        return URLEncoder.encode(nullToEmpty(value), StandardCharsets.UTF_8.name());
+    }
+    
+    private String trimTrailingSlash(String value) throws NacosException {
+        if (StringUtils.isBlank(value)) {
+            throw invalid("SkillHub import source endpoint must not be empty.");
+        }
+        String result = value.trim();
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+    
+    private String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+    
+    private String firstText(JsonNode item, String... keys) {
+        for (String key : keys) {
+            String value = textOrEmpty(item.get(key));
+            if (StringUtils.isNotBlank(value)) {
+                return value;
+            }
+        }
+        return "";
+    }
+    
+    private String textOrEmpty(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return "";
+        }
+        if (node.isTextual() || node.isNumber() || node.isBoolean()) {
+            return node.asText().trim();
+        }
+        return "";
+    }
+    
+    private String sha256Hex(byte[] data) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(data);
+        StringBuilder result = new StringBuilder(hash.length * 2);
+        for (byte b : hash) {
+            result.append(String.format("%02x", b));
+        }
+        return result.toString();
+    }
+    
+    private NacosException invalid(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                message);
+    }
+    
+    private NacosException dataAccess(String message, Throwable cause) {
+        return new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.DATA_ACCESS_ERROR, cause,
+                message);
+    }
+    
+    static class SkillHubRemoteSkill {
+        
+        private final String canonicalSlug;
+        
+        private final String localName;
+        
+        private final String version;
+        
+        private final String description;
+        
+        private final String namespace;
+        
+        SkillHubRemoteSkill(String canonicalSlug, String localName, String version,
+                String description) {
+            this(canonicalSlug, localName, version, description, null);
+        }
+        
+        SkillHubRemoteSkill(String canonicalSlug, String localName, String version,
+                String description, String namespace) {
+            this.canonicalSlug = canonicalSlug;
+            this.localName = localName;
+            this.version = version;
+            this.description = description == null ? "" : description;
+            this.namespace = namespace;
+        }
+        
+        public String getCanonicalSlug() {
+            return canonicalSlug;
+        }
+        
+        public String getLocalName() {
+            return localName;
+        }
+        
+        public String getVersion() {
+            return version;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+        
+        public String getNamespace() {
+            return namespace;
+        }
+    }
+    
+    static class RedirectRewrite {
+        
+        private final String fetchUrl;
+        
+        private final String hostHeader;
+        
+        RedirectRewrite(String fetchUrl, String hostHeader) {
+            this.fetchUrl = fetchUrl;
+            this.hostHeader = hostHeader;
+        }
+        
+        public String getFetchUrl() {
+            return fetchUrl;
+        }
+        
+        public String getHostHeader() {
+            return hostHeader;
+        }
+    }
+    
+    private static class ListStrategy {
+        
+        private final String path;
+        
+        private final String query;
+        
+        ListStrategy(String path, String query) {
+            this.path = path;
+            this.query = query;
+        }
+    }
+}

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportServiceBuilder.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportServiceBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub;
+
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder;
+
+import java.util.Properties;
+
+/**
+ * Builder for the SkillHub AI resource import service (Nacos 3.2.x SPI).
+ *
+ * @author nacos
+ */
+public class SkillHubImportServiceBuilder implements AiResourceImportServiceBuilder {
+    
+    public static final String IMPORTER_TYPE = "skillhub";
+    
+    @Override
+    public String importerType() {
+        return IMPORTER_TYPE;
+    }
+    
+    @Override
+    public AiResourceImportService build(Properties properties) {
+        return new SkillHubImportService();
+    }
+}

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportSourceProvider.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportSourceProvider.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.AiResourceImportConstants;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportSourceProvider;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Registers the SkillHub import source from application.properties (Nacos 3.2.x SPI).
+ *
+ * <p>Prefix: {@code nacos.plugin.ai.importer.skills.skillhub.}
+ *
+ * @author nacos
+ */
+public class SkillHubImportSourceProvider implements AiResourceImportSourceProvider {
+    
+    public static final String PREFIX = "nacos.plugin.ai.importer.skills.skillhub.";
+    
+    public static final String PROPERTY_TOKEN = "token";
+    
+    public static final String PROPERTY_NAMESPACE = "namespace";
+    
+    public static final String PROPERTY_REDIRECT_HOST_MAP = "redirect-host-map";
+    
+    public static final String PROPERTY_ALLOW_HTTP = "allow-http";
+    
+    public static final String PROPERTY_ALLOW_PRIVATE_NETWORK = "allow-private-network";
+    
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 3000;
+    
+    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 30000;
+    
+    private static final int DEFAULT_MAX_PAGE_COUNT = 20;
+    
+    private static final int DEFAULT_MAX_ITEM_COUNT = 500;
+    
+    private static final long DEFAULT_MAX_ARTIFACT_SIZE = 10L * 1024L * 1024L;
+    
+    @Override
+    public Collection<AiResourceImportSource> loadSources(Properties properties)
+            throws NacosException {
+        if (!getBoolean(properties, PREFIX + "enabled", false)) {
+            return Collections.emptyList();
+        }
+        String endpoint = getString(properties, PREFIX, "endpoint", "url", null);
+        if (StringUtils.isBlank(endpoint)) {
+            throw invalidConfig("SkillHub import source endpoint must not be empty when enabled.");
+        }
+        String token = getString(properties, PREFIX, PROPERTY_TOKEN, "api-token", null);
+        if (StringUtils.isBlank(token)) {
+            throw invalidConfig("SkillHub import source token must not be empty when enabled.");
+        }
+        // Optional default namespace. Search may override with options.namespace or "@ns ..." query.
+        String namespace = SkillHubSlug.normalizeNamespace(
+                getString(properties, PREFIX, PROPERTY_NAMESPACE, "namespaceSlug", null));
+        
+        AiResourceImportSource result = new AiResourceImportSource();
+        result.setSourceId(getString(properties, PREFIX, "source-id", "sourceId", "skillhub"));
+        result.setDisplayName(
+                getString(properties, PREFIX, "display-name", "displayName", "SkillHub"));
+        result.setDescription(getString(properties, PREFIX, "description", "description",
+                "Import Skills from an authenticated SkillHub registry. "
+                        + "Default namespace is global; use @namespace or @namespace keyword to switch."));
+        result.setPluginName(SkillHubImportServiceBuilder.IMPORTER_TYPE);
+        result.setResourceTypes(
+                Collections.singletonList(AiResourceImportConstants.RESOURCE_TYPE_SKILL));
+        result.setEndpoint(endpoint);
+        result.setEnabled(true);
+        result.setAuthRef(getString(properties, PREFIX, "auth-ref", "authRef", null));
+        result.setConnectTimeoutMillis(
+                getInt(properties, PREFIX + "connect-timeout-ms", DEFAULT_CONNECT_TIMEOUT_MILLIS));
+        result.setReadTimeoutMillis(
+                getInt(properties, PREFIX + "read-timeout-ms", DEFAULT_READ_TIMEOUT_MILLIS));
+        result.setMaxPageCount(getInt(properties, PREFIX + "max-page-count", DEFAULT_MAX_PAGE_COUNT));
+        result.setMaxItemCount(getInt(properties, PREFIX + "max-item-count", DEFAULT_MAX_ITEM_COUNT));
+        result.setMaxArtifactSize(
+                getLong(properties, PREFIX + "max-artifact-size", DEFAULT_MAX_ARTIFACT_SIZE));
+        
+        Map<String, String> sourceProperties = new LinkedHashMap<String, String>();
+        sourceProperties.put(PROPERTY_TOKEN, token.trim());
+        if (StringUtils.isNotBlank(namespace)) {
+            sourceProperties.put(PROPERTY_NAMESPACE, namespace);
+        }
+        putIfPresent(properties, PREFIX, PROPERTY_ALLOW_HTTP, "allowHttp", sourceProperties);
+        putIfPresent(properties, PREFIX, PROPERTY_ALLOW_PRIVATE_NETWORK, "allowPrivateNetwork",
+                sourceProperties);
+        putIfPresent(properties, PREFIX, PROPERTY_REDIRECT_HOST_MAP, "redirectHostMap",
+                sourceProperties);
+        result.setProperties(sourceProperties);
+        
+        List<AiResourceImportSource> sources = new ArrayList<AiResourceImportSource>(1);
+        sources.add(result);
+        return sources;
+    }
+    
+    private void putIfPresent(Properties properties, String prefix, String kebabKey, String camelKey,
+            Map<String, String> target) {
+        String value = getString(properties, prefix, kebabKey, camelKey, null);
+        if (StringUtils.isNotBlank(value)) {
+            target.put(kebabKey, value.trim());
+        }
+    }
+    
+    private String getString(Properties properties, String prefix, String kebabKey, String camelKey,
+            String defaultValue) {
+        String value = properties.getProperty(prefix + kebabKey);
+        if (StringUtils.isBlank(value)) {
+            value = properties.getProperty(prefix + camelKey);
+        }
+        return StringUtils.isBlank(value) ? defaultValue : value.trim();
+    }
+    
+    private boolean getBoolean(Properties properties, String key, boolean defaultValue) {
+        String value = properties.getProperty(key);
+        return StringUtils.isBlank(value) ? defaultValue : Boolean.parseBoolean(value);
+    }
+    
+    private int getInt(Properties properties, String key, int defaultValue) {
+        String value = properties.getProperty(key);
+        return StringUtils.isBlank(value) ? defaultValue : Integer.parseInt(value);
+    }
+    
+    private long getLong(Properties properties, String key, long defaultValue) {
+        String value = properties.getProperty(key);
+        return StringUtils.isBlank(value) ? defaultValue : Long.parseLong(value);
+    }
+    
+    private NacosException invalidConfig(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, message);
+    }
+}

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubSlug.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubSlug.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+
+/**
+ * SkillHub namespace / canonical slug helpers (ported from base_agent skillhub_slug).
+ *
+ * @author nacos
+ */
+public final class SkillHubSlug {
+    
+    private SkillHubSlug() {
+    }
+    
+    public static String normalizeNamespace(String namespace) {
+        String cleaned = namespace == null ? "" : namespace.trim();
+        if (cleaned.startsWith("@")) {
+            cleaned = cleaned.substring(1).trim();
+        }
+        return cleaned;
+    }
+    
+    public static String hubCanonicalSlug(String namespace, String skillName) {
+        String ns = normalizeNamespace(namespace);
+        String name = skillName == null ? "" : skillName.trim();
+        if (StringUtils.isBlank(ns) || StringUtils.isBlank(name)) {
+            throw new IllegalArgumentException("namespace and skill_name are required");
+        }
+        if ("global".equals(ns)) {
+            return name;
+        }
+        return ns + "--" + name;
+    }
+    
+    public static String localSkillNameFromCanonical(String namespace, String canonicalSlug) {
+        String ns = normalizeNamespace(namespace);
+        String slug = canonicalSlug == null ? "" : canonicalSlug.trim();
+        if (StringUtils.isBlank(slug)) {
+            throw new IllegalArgumentException("canonical_slug is required");
+        }
+        if ("global".equals(ns)) {
+            String prefix = "global--";
+            if (slug.startsWith(prefix)) {
+                return slug.substring(prefix.length());
+            }
+            return slug;
+        }
+        String prefix = ns + "--";
+        if (slug.startsWith(prefix)) {
+            return slug.substring(prefix.length());
+        }
+        if (!slug.contains("--")) {
+            return slug;
+        }
+        int index = slug.indexOf("--");
+        return slug.substring(index + 2);
+    }
+    
+    public static boolean skillBelongsToNamespace(String namespace, String canonicalSlug) {
+        String ns = normalizeNamespace(namespace);
+        String slug = canonicalSlug == null ? "" : canonicalSlug.trim();
+        if (StringUtils.isBlank(slug)) {
+            return false;
+        }
+        if ("global".equals(ns)) {
+            return !slug.contains("--") || slug.startsWith("global--");
+        }
+        return slug.startsWith(ns + "--");
+    }
+    
+    /**
+     * Parse search input into namespace + keyword.
+     *
+     * <p>Supported forms:
+     * <ul>
+     *   <li>{@code @team-x} → namespace=team-x, keyword empty</li>
+     *   <li>{@code @team-x alpha} → namespace=team-x, keyword=alpha</li>
+     *   <li>{@code @team-x/alpha} → namespace=team-x, keyword=alpha</li>
+     *   <li>{@code team-x--alpha} → namespace=team-x, keyword=alpha</li>
+     *   <li>{@code alpha} → namespace from defaultNamespace, keyword=alpha</li>
+     * </ul>
+     */
+    public static NamespaceQuery parseSearchQuery(String rawQuery, String defaultNamespace) {
+        String query = rawQuery == null ? "" : rawQuery.trim();
+        if (query.startsWith("@")) {
+            String body = query.substring(1).trim();
+            if (StringUtils.isBlank(body)) {
+                return new NamespaceQuery(normalizeNamespace(defaultNamespace), "");
+            }
+            int slash = indexOfNamespaceSeparator(body, '/');
+            int space = indexOfNamespaceSeparator(body, ' ');
+            int split = earliestPositive(slash, space);
+            if (split > 0) {
+                String ns = normalizeNamespace(body.substring(0, split));
+                String keyword = body.substring(split + 1).trim();
+                return new NamespaceQuery(ns, keyword);
+            }
+            return new NamespaceQuery(normalizeNamespace(body), "");
+        }
+        if (query.contains("--")) {
+            int index = query.indexOf("--");
+            String ns = normalizeNamespace(query.substring(0, index));
+            String keyword = query.substring(index + 2).trim();
+            if (StringUtils.isNotBlank(ns)) {
+                return new NamespaceQuery(ns, keyword);
+            }
+        }
+        return new NamespaceQuery(normalizeNamespace(defaultNamespace), query);
+    }
+    
+    private static int indexOfNamespaceSeparator(String value, char separator) {
+        int index = value.indexOf(separator);
+        return index < 0 ? -1 : index;
+    }
+    
+    private static int earliestPositive(int left, int right) {
+        if (left < 0) {
+            return right;
+        }
+        if (right < 0) {
+            return left;
+        }
+        return Math.min(left, right);
+    }
+    
+    /**
+     * Namespace + remaining keyword from a search query.
+     */
+    public static final class NamespaceQuery {
+        
+        private final String namespace;
+        
+        private final String keyword;
+        
+        public NamespaceQuery(String namespace, String keyword) {
+            this.namespace = namespace == null ? "" : namespace;
+            this.keyword = keyword == null ? "" : keyword;
+        }
+        
+        public String getNamespace() {
+            return namespace;
+        }
+        
+        public String getKeyword() {
+            return keyword;
+        }
+    }
+}

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/http/DefaultSkillHubHttpClient.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/http/DefaultSkillHubHttpClient.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub.http;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.skillhub.SkillHubImportConfig;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Locale;
+
+/**
+ * Default URLConnection-based SkillHub HTTP client.
+ *
+ * @author nacos
+ */
+public class DefaultSkillHubHttpClient implements SkillHubHttpClient {
+    
+    private static final String HTTPS = "https";
+    
+    @Override
+    public SkillHubHttpResponse get(SkillHubImportConfig config, String url, boolean followRedirects,
+            String hostHeader, boolean withAuth) throws Exception {
+        URL target = new URL(url);
+        validateTarget(config, target);
+        HttpURLConnection connection = (HttpURLConnection) target.openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(config.getConnectTimeoutMillis());
+        connection.setReadTimeout(config.getReadTimeoutMillis());
+        connection.setInstanceFollowRedirects(followRedirects);
+        connection.setRequestProperty("Accept", "*/*");
+        if (StringUtils.isNotBlank(hostHeader)) {
+            connection.setRequestProperty("Host", hostHeader.trim());
+        }
+        if (withAuth) {
+            String token = config.getToken();
+            if (StringUtils.isNotBlank(token)) {
+                connection.setRequestProperty("Authorization", "Bearer " + token.trim());
+            }
+        }
+        int statusCode = connection.getResponseCode();
+        String location = connection.getHeaderField("Location");
+        InputStream stream = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        byte[] body = readBody(stream);
+        connection.disconnect();
+        return new SkillHubHttpResponse(url, statusCode, body, location);
+    }
+    
+    private void validateTarget(SkillHubImportConfig config, URL target)
+            throws UnknownHostException {
+        String protocol = target.getProtocol().toLowerCase(Locale.ENGLISH);
+        if (!HTTPS.equals(protocol) && !config.isAllowHttp()) {
+            throw new IllegalArgumentException(
+                    "SkillHub importer requires HTTPS endpoints unless allow-http is enabled.");
+        }
+        if (!config.isAllowPrivateNetwork()) {
+            InetAddress[] addresses = InetAddress.getAllByName(target.getHost());
+            for (InetAddress address : addresses) {
+                if (isPrivateAddress(address)) {
+                    throw new IllegalArgumentException(
+                            "SkillHub importer rejects private network endpoints by default.");
+                }
+            }
+        }
+    }
+    
+    private boolean isPrivateAddress(InetAddress address) {
+        return address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress() || address.isMulticastAddress();
+    }
+    
+    private byte[] readBody(InputStream input) throws IOException {
+        if (input == null) {
+            return new byte[0];
+        }
+        try (InputStream stream = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[4096];
+            int len;
+            while ((len = stream.read(buffer)) >= 0) {
+                output.write(buffer, 0, len);
+            }
+            return output.toByteArray();
+        }
+    }
+}

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/http/SkillHubHttpClient.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/http/SkillHubHttpClient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub.http;
+
+import com.alibaba.nacos.plugin.ai.importer.skillhub.SkillHubImportConfig;
+
+/**
+ * HTTP client abstraction for SkillHub API calls.
+ *
+ * @author nacos
+ */
+public interface SkillHubHttpClient {
+    
+    /**
+     * Execute an HTTP GET request.
+     *
+     * @param config import configuration
+     * @param url target URL
+     * @param followRedirects whether to follow redirects automatically
+     * @param hostHeader optional Host header override (used after redirect rewrite)
+     * @param withAuth whether to send the Bearer token
+     * @return response
+     * @throws Exception if the request fails
+     */
+    SkillHubHttpResponse get(SkillHubImportConfig config, String url, boolean followRedirects,
+            String hostHeader, boolean withAuth) throws Exception;
+}

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/http/SkillHubHttpResponse.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/skillhub/http/SkillHubHttpResponse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub.http;
+
+/**
+ * HTTP response for SkillHub API calls.
+ *
+ * @author nacos
+ */
+public class SkillHubHttpResponse {
+    
+    private final String url;
+    
+    private final int statusCode;
+    
+    private final byte[] body;
+    
+    private final String location;
+    
+    public SkillHubHttpResponse(String url, int statusCode, byte[] body) {
+        this(url, statusCode, body, null);
+    }
+    
+    public SkillHubHttpResponse(String url, int statusCode, byte[] body, String location) {
+        this.url = url;
+        this.statusCode = statusCode;
+        this.body = body == null ? new byte[0] : body;
+        this.location = location;
+    }
+    
+    public String getUrl() {
+        return url;
+    }
+    
+    public int getStatusCode() {
+        return statusCode;
+    }
+    
+    public byte[] getBody() {
+        return body;
+    }
+    
+    public String getLocation() {
+        return location;
+    }
+    
+    public boolean isSuccess() {
+        return statusCode >= 200 && statusCode < 300;
+    }
+    
+    public boolean isRedirect() {
+        return statusCode >= 300 && statusCode < 400;
+    }
+}

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder
@@ -1,0 +1,1 @@
+com.alibaba.nacos.plugin.ai.importer.skillhub.SkillHubImportServiceBuilder

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportSourceProvider
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportSourceProvider
@@ -1,0 +1,1 @@
+com.alibaba.nacos.plugin.ai.importer.skillhub.SkillHubImportSourceProvider

--- a/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportServiceTest.java
+++ b/nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/skillhub/SkillHubImportServiceTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.plugin.ai.importer.skillhub;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.plugin.ai.importer.AiResourceImportConstants;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidatePage;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportContext;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import com.alibaba.nacos.plugin.ai.importer.skillhub.http.SkillHubHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.skillhub.http.SkillHubHttpResponse;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for SkillHub importer (Nacos 3.2.x SPI).
+ *
+ * @author nacos
+ */
+public class SkillHubImportServiceTest {
+    
+    @Test
+    public void testBuilderAndSourceProvider() throws Exception {
+        SkillHubImportServiceBuilder builder = new SkillHubImportServiceBuilder();
+        assertEquals(SkillHubImportServiceBuilder.IMPORTER_TYPE, builder.importerType());
+        assertTrue(builder.build(new Properties()) instanceof SkillHubImportService);
+        
+        Properties properties = new Properties();
+        properties.setProperty(SkillHubImportSourceProvider.PREFIX + "enabled", "true");
+        properties.setProperty(SkillHubImportSourceProvider.PREFIX + "endpoint",
+                "https://hub.example.com");
+        properties.setProperty(SkillHubImportSourceProvider.PREFIX + "token", "secret");
+        properties.setProperty(SkillHubImportSourceProvider.PREFIX + "allow-private-network", "true");
+        
+        Collection<AiResourceImportSource> sources =
+                new SkillHubImportSourceProvider().loadSources(properties);
+        assertEquals(1, sources.size());
+        AiResourceImportSource source = sources.iterator().next();
+        assertEquals("skillhub", source.getPluginName());
+        assertEquals("https://hub.example.com", source.getEndpoint());
+        assertFalse(source.getProperties().containsKey(SkillHubImportSourceProvider.PROPERTY_NAMESPACE));
+        assertEquals("secret", source.getProperties().get(SkillHubImportSourceProvider.PROPERTY_TOKEN));
+        assertEquals(Collections.singletonList(AiResourceImportConstants.RESOURCE_TYPE_SKILL),
+                source.getResourceTypes());
+    }
+    
+    @Test
+    public void testSourceProviderOptionalNamespace() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(SkillHubImportSourceProvider.PREFIX + "enabled", "true");
+        properties.setProperty(SkillHubImportSourceProvider.PREFIX + "endpoint",
+                "https://hub.example.com");
+        properties.setProperty(SkillHubImportSourceProvider.PREFIX + "token", "secret");
+        properties.setProperty(SkillHubImportSourceProvider.PREFIX + "namespace", "@team-x");
+        AiResourceImportSource source =
+                new SkillHubImportSourceProvider().loadSources(properties).iterator().next();
+        assertEquals("team-x", source.getProperties().get(SkillHubImportSourceProvider.PROPERTY_NAMESPACE));
+    }
+    
+    @Test
+    public void testSearchUsesAtNamespaceInQuery() throws Exception {
+        FakeHttpClient client = new FakeHttpClient();
+        SkillHubImportService service = new SkillHubImportService(client);
+        AiResourceImportSource source = defaultSource();
+        source.getProperties().remove(SkillHubImportSourceProvider.PROPERTY_NAMESPACE);
+        AiResourceImportContext context = newContext(source);
+        context.setQuery("@team-x alpha");
+        context.setLimit(10);
+        
+        AiResourceImportCandidatePage result = service.search(context);
+        assertEquals(1, result.getItems().size());
+        assertEquals("team-x--alpha", result.getItems().get(0).getExternalId());
+        assertEquals("team-x", result.getItems().get(0).getMetadata().get("namespace"));
+        assertTrue(client.urls.get(0).contains("/api/v1/skills?namespaceSlug=team-x"));
+    }
+    
+    @Test
+    public void testSearchDefaultsToGlobalWhenNamespaceMissing() throws Exception {
+        FakeHttpClient client = new FakeHttpClient();
+        client.listBody = "{\"data\":["
+                + "{\"slug\":\"alpha\",\"description\":\"global skill\","
+                + "\"publishedVersion\":{\"version\":\"1.0.0\"}}"
+                + "]}";
+        SkillHubImportService service = new SkillHubImportService(client);
+        AiResourceImportSource source = defaultSource();
+        source.getProperties().remove(SkillHubImportSourceProvider.PROPERTY_NAMESPACE);
+        AiResourceImportContext context = newContext(source);
+        context.setQuery("alpha");
+        
+        AiResourceImportCandidatePage result = service.search(context);
+        assertEquals(1, result.getItems().size());
+        assertEquals("alpha", result.getItems().get(0).getExternalId());
+        assertEquals("global", result.getItems().get(0).getMetadata().get("namespace"));
+        assertTrue(client.urls.get(0).contains("/api/v1/skills?namespaceSlug=global")
+                || client.urls.get(0).contains("/api/v1/search?q="));
+    }
+    
+    @Test
+    public void testSearchReturnsCandidatesAndFiltersQuery() throws Exception {
+        FakeHttpClient client = new FakeHttpClient();
+        SkillHubImportService service = new SkillHubImportService(client);
+        AiResourceImportContext context = newContext(defaultSource());
+        context.setQuery("alpha");
+        context.setLimit(10);
+        
+        AiResourceImportCandidatePage result = service.search(context);
+        assertEquals(1, result.getItems().size());
+        assertFalse(result.isHasMore());
+        assertEquals("team-x--alpha", result.getItems().get(0).getExternalId());
+        assertEquals("alpha", result.getItems().get(0).getName());
+        assertEquals("1.0.0", result.getItems().get(0).getVersion());
+        assertEquals("skill", result.getItems().get(0).getResourceType());
+        assertEquals("team-x", result.getItems().get(0).getMetadata().get("namespace"));
+        assertEquals("1.0.0", result.getItems().get(0).getMetadata().get("version"));
+        assertTrue(client.urls.get(0).contains("/api/v1/skills?namespaceSlug=team-x"));
+    }
+    
+    @Test
+    public void testSearchSkipsUnprovenGlobalShortSlug() throws Exception {
+        FakeHttpClient client = new FakeHttpClient();
+        client.listBody = "{\"data\":["
+                + "{\"slug\":\"leaked\",\"description\":\"global leak\",\"version\":\"9.0.0\"},"
+                + "{\"slug\":\"team-x--alpha\",\"description\":\"ok\",\"publishedVersion\":{\"version\":\"1.0.0\"}}"
+                + "]}";
+        SkillHubImportService service = new SkillHubImportService(client);
+        AiResourceImportCandidatePage result = service.search(newContext(defaultSource()));
+        assertEquals(1, result.getItems().size());
+        assertEquals("team-x--alpha", result.getItems().get(0).getExternalId());
+    }
+    
+    @Test
+    public void testFetchReturnsSkillZipArtifact() throws Exception {
+        FakeHttpClient client = new FakeHttpClient();
+        SkillHubImportService service = new SkillHubImportService(client);
+        AiResourceImportArtifact result = service.fetch(newContext(defaultSource()),
+                item("team-x--alpha", "alpha", "1.0.0"));
+        assertEquals("skill", result.getResourceType());
+        assertEquals("team-x--alpha", result.getExternalId());
+        assertEquals("alpha", result.getName());
+        assertEquals(AiResourceImportPayloadKind.SKILL_ZIP, result.getPayloadKind());
+        assertNotNull(result.getChecksum());
+        assertEquals(64, result.getChecksum().length());
+        assertTrue(client.urls.get(0).contains(
+                "/api/v1/skills/team-x/alpha/versions/1.0.0/download"));
+    }
+    
+    @Test
+    public void testFetchFollowsRedirectWithHostRewrite() throws Exception {
+        FakeHttpClient client = new FakeHttpClient();
+        client.redirectFirstDownload = true;
+        AiResourceImportSource source = defaultSource();
+        source.getProperties().put(SkillHubImportSourceProvider.PROPERTY_REDIRECT_HOST_MAP,
+                "minio:10.0.0.1");
+        SkillHubImportService service = new SkillHubImportService(client);
+        
+        AiResourceImportArtifact result = service.fetch(newContext(source),
+                item("team-x--alpha", "alpha", "1.0.0"));
+        assertEquals(AiResourceImportPayloadKind.SKILL_ZIP, result.getPayloadKind());
+        assertTrue(client.urls.stream().anyMatch(url -> url.startsWith("http://10.0.0.1:9000/")));
+        assertEquals("minio:9000", client.lastHostHeader);
+    }
+    
+    @Test
+    public void testFetchUsesClawHubCompatibleDownloadFallback() throws Exception {
+        FakeHttpClient client = new FakeHttpClient();
+        client.failSkillsDownload = true;
+        client.redirectClawHubDownload = true;
+        SkillHubImportService service = new SkillHubImportService(client);
+        
+        AiResourceImportArtifact result = service.fetch(newContext(defaultSource()),
+                item("team-x--alpha", "alpha", "1.0.0"));
+        assertEquals(AiResourceImportPayloadKind.SKILL_ZIP, result.getPayloadKind());
+        assertTrue(client.urls.stream().anyMatch(
+                url -> url.contains("/api/v1/download/team-x--alpha?version=1.0.0")));
+        assertTrue(client.urls.stream().anyMatch(
+                url -> url.contains("/api/v1/skills/team-x/alpha/versions/1.0.0/download")));
+        assertTrue(client.authFlags.contains(Boolean.TRUE));
+    }
+    
+    @Test
+    public void testRewriteRedirectDefaultsMinioToApiHost() throws Exception {
+        SkillHubImportConfig config = new SkillHubImportConfig(defaultSource());
+        SkillHubImportService service = new SkillHubImportService(new FakeHttpClient());
+        SkillHubImportService.RedirectRewrite rewrite = service.rewriteRedirectLocation(config,
+                "http://minio:9000/bucket/pkg.zip");
+        assertEquals("http://hub.example.com:9000/bucket/pkg.zip", rewrite.getFetchUrl());
+        assertEquals("minio:9000", rewrite.getHostHeader());
+    }
+    
+    @Test(expected = NacosException.class)
+    public void testFetchRejectsMissingVersion() throws Exception {
+        AiResourceImportItem item = new AiResourceImportItem();
+        item.setExternalId("team-x--alpha");
+        item.setName("alpha");
+        new SkillHubImportService(new FakeHttpClient())
+                .fetch(newContext(defaultSource()), item);
+    }
+    
+    @Test(expected = NacosException.class)
+    public void testFetchRejectsSizeLimit() throws Exception {
+        AiResourceImportSource source = defaultSource();
+        source.setMaxArtifactSize(1L);
+        new SkillHubImportService(new FakeHttpClient())
+                .fetch(newContext(source), item("team-x--alpha", "alpha", "1.0.0"));
+    }
+    
+    @Test(expected = NacosException.class)
+    public void testFetchRejectsHttpError() throws Exception {
+        FakeHttpClient client = new FakeHttpClient();
+        client.downloadStatus = 500;
+        new SkillHubImportService(client)
+                .fetch(newContext(defaultSource()), item("team-x--alpha", "alpha", "1.0.0"));
+    }
+    
+    @Test
+    public void testSlugHelpers() {
+        assertEquals("team-x", SkillHubSlug.normalizeNamespace("@team-x"));
+        assertEquals("team-x--alpha", SkillHubSlug.hubCanonicalSlug("team-x", "alpha"));
+        assertEquals("alpha", SkillHubSlug.hubCanonicalSlug("global", "alpha"));
+        assertEquals("alpha", SkillHubSlug.localSkillNameFromCanonical("team-x", "team-x--alpha"));
+        assertTrue(SkillHubSlug.skillBelongsToNamespace("team-x", "team-x--alpha"));
+        assertFalse(SkillHubSlug.skillBelongsToNamespace("team-x", "other--alpha"));
+        SkillHubSlug.NamespaceQuery query = SkillHubSlug.parseSearchQuery("@team-x alpha", "");
+        assertEquals("team-x", query.getNamespace());
+        assertEquals("alpha", query.getKeyword());
+        SkillHubSlug.NamespaceQuery slash = SkillHubSlug.parseSearchQuery("@team-x/alpha", "global");
+        assertEquals("team-x", slash.getNamespace());
+        assertEquals("alpha", slash.getKeyword());
+        SkillHubSlug.NamespaceQuery fallback = SkillHubSlug.parseSearchQuery("alpha", "global");
+        assertEquals("global", fallback.getNamespace());
+        assertEquals("alpha", fallback.getKeyword());
+    }
+    
+    private AiResourceImportContext newContext(AiResourceImportSource source) {
+        AiResourceImportContext context = new AiResourceImportContext();
+        context.setSource(source);
+        return context;
+    }
+    
+    private AiResourceImportSource defaultSource() {
+        AiResourceImportSource source = new AiResourceImportSource();
+        source.setSourceId("skillhub");
+        source.setPluginName(SkillHubImportServiceBuilder.IMPORTER_TYPE);
+        source.setEndpoint("https://hub.example.com");
+        source.setEnabled(true);
+        source.setConnectTimeoutMillis(3000);
+        source.setReadTimeoutMillis(30000);
+        source.setMaxItemCount(100);
+        source.setMaxArtifactSize(10L * 1024L * 1024L);
+        source.setResourceTypes(
+                Collections.singletonList(AiResourceImportConstants.RESOURCE_TYPE_SKILL));
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put(SkillHubImportSourceProvider.PROPERTY_TOKEN, "token");
+        properties.put(SkillHubImportSourceProvider.PROPERTY_NAMESPACE, "team-x");
+        properties.put(SkillHubImportSourceProvider.PROPERTY_ALLOW_PRIVATE_NETWORK, "true");
+        source.setProperties(properties);
+        return source;
+    }
+    
+    private AiResourceImportItem item(String externalId, String name, String version) {
+        AiResourceImportItem item = new AiResourceImportItem();
+        item.setExternalId(externalId);
+        item.setName(name);
+        Map<String, String> metadata = new HashMap<String, String>();
+        metadata.put("namespace", "team-x");
+        metadata.put("skillId", name);
+        metadata.put("version", version);
+        metadata.put("canonicalSlug", externalId);
+        item.setMetadata(metadata);
+        return item;
+    }
+    
+    private static byte[] sampleZip() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(output, StandardCharsets.UTF_8)) {
+            zip.putNextEntry(new ZipEntry("alpha/SKILL.md"));
+            zip.write("---\nname: alpha\ndescription: demo\n---\n".getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+        return output.toByteArray();
+    }
+    
+    private static class FakeHttpClient implements SkillHubHttpClient {
+        
+        private final List<String> urls = new ArrayList<String>();
+        
+        private final List<Boolean> authFlags = new ArrayList<Boolean>();
+        
+        private String listBody = "{\"data\":["
+                + "{\"slug\":\"team-x--alpha\",\"description\":\"Alpha skill\","
+                + "\"publishedVersion\":{\"version\":\"1.0.0\"}},"
+                + "{\"slug\":\"team-x--beta\",\"description\":\"Beta skill\","
+                + "\"publishedVersion\":{\"version\":\"2.0.0\"}}"
+                + "]}";
+        
+        private int downloadStatus = 200;
+        
+        private boolean redirectFirstDownload;
+        
+        private boolean failSkillsDownload;
+        
+        private boolean redirectClawHubDownload;
+        
+        private boolean clawHubRedirectSeen;
+        
+        private String lastHostHeader;
+        
+        @Override
+        public SkillHubHttpResponse get(SkillHubImportConfig config, String url,
+                boolean followRedirects, String hostHeader, boolean withAuth) throws Exception {
+            urls.add(url);
+            authFlags.add(withAuth);
+            lastHostHeader = hostHeader;
+            if (url.contains("/api/v1/skills?") || url.contains("/api/web/skills")
+                    || url.contains("/api/v1/search")) {
+                return new SkillHubHttpResponse(url, 200,
+                        listBody.getBytes(StandardCharsets.UTF_8));
+            }
+            if (url.contains("/api/v1/download/") || url.contains("/api/v1/download?")) {
+                if (redirectClawHubDownload) {
+                    clawHubRedirectSeen = true;
+                    return new SkillHubHttpResponse(url, 302, new byte[0],
+                            "/api/v1/skills/team-x/alpha/versions/1.0.0/download");
+                }
+                if (downloadStatus >= 400) {
+                    return new SkillHubHttpResponse(url, downloadStatus,
+                            "{\"msg\":\"error\"}".getBytes(StandardCharsets.UTF_8));
+                }
+                return new SkillHubHttpResponse(url, 200, sampleZip());
+            }
+            if (url.contains("/download") || url.contains(":9000/")) {
+                if (failSkillsDownload && url.contains("/api/v1/skills/") && !clawHubRedirectSeen) {
+                    return new SkillHubHttpResponse(url, 405,
+                            "{\"msg\":\"method not allowed\"}".getBytes(StandardCharsets.UTF_8));
+                }
+                if (redirectFirstDownload && url.contains("/api/v1/skills/")
+                        && !url.contains(":9000/")) {
+                    redirectFirstDownload = false;
+                    return new SkillHubHttpResponse(url, 302, new byte[0],
+                            "http://minio:9000/skillhub-skills/pkg.zip");
+                }
+                if (downloadStatus >= 400) {
+                    return new SkillHubHttpResponse(url, downloadStatus,
+                            "{\"msg\":\"error\"}".getBytes(StandardCharsets.UTF_8));
+                }
+                return new SkillHubHttpResponse(url, 200, sampleZip());
+            }
+            return new SkillHubHttpResponse(url, 404, new byte[0]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `nacos-skillhub-ai-importer-plugin` to import Skill resources from an authenticated SkillHub registry via Nacos AI importer SPI.
- Register the plugin module under `nacos-ai-importer-plugin-ext` and document configuration/search syntax in README.
- Include unit coverage for SkillHub import service behavior.

## Test plan
- [ ] `mvn -pl nacos-ai-importer-plugin-ext/nacos-skillhub-ai-importer-plugin -am test`
- [ ] Build the plugin JAR and drop it into Nacos `plugins/`
- [ ] Enable SkillHub importer in `application.properties` and verify search/import against a real SkillHub endpoint
- [ ] Confirm disabled/misconfigured sources fail fast with clear config errors


Made with [Cursor](https://cursor.com)