### PR TITLE
fix(dm): remove MySQL backticks from usage column in capacity mappers

### DIFF
--- a/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dm/GroupCapacityMapperByDaMeng.java
+++ b/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dm/GroupCapacityMapperByDaMeng.java
@@ -53,7 +53,7 @@ public class GroupCapacityMapperByDaMeng extends AbstractMapperByDaMeng implemen
     
     @Override
     public MapperResult select(MapperContext context) {
-        String sql = "SELECT id, quota, `usage`, max_size, max_aggr_count, max_aggr_size, group_id FROM group_capacity "
+        String sql = "SELECT id, quota, usage, max_size, max_aggr_count, max_aggr_size, group_id FROM group_capacity "
                 + "WHERE group_id = ?";
         return new MapperResult(sql, Collections.singletonList(context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
@@ -70,7 +70,7 @@ public class GroupCapacityMapperByDaMeng extends AbstractMapperByDaMeng implemen
         paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
         
         String sql =
-                "INSERT INTO group_capacity (group_id, quota, `usage`, max_size, max_aggr_count, max_aggr_size,gmt_create,"
+                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size,gmt_create,"
                         + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info";
         return new MapperResult(sql, paramList);
     }
@@ -78,7 +78,7 @@ public class GroupCapacityMapperByDaMeng extends AbstractMapperByDaMeng implemen
     @Override
     public MapperResult insertIntoSelectByWhere(MapperContext context) {
         String sql =
-                "INSERT INTO group_capacity (group_id, quota, `usage`, max_size, max_aggr_count, max_aggr_size, gmt_create,"
+                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size, gmt_create,"
                         + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE group_id=? AND tenant_id = '"
                         + NamespaceUtil.getNamespaceDefaultId() + "'";
         List<Object> paramList = new ArrayList<>();
@@ -97,42 +97,42 @@ public class GroupCapacityMapperByDaMeng extends AbstractMapperByDaMeng implemen
     
     @Override
     public MapperResult incrementUsageByWhereQuotaEqualZero(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = `usage` + 1, gmt_modified = ? WHERE group_id = ? AND `usage` < ? AND quota = 0";
+        String sql = "UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ? AND usage < ? AND quota = 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID), context.getWhereParameter(FieldConstant.USAGE)));
     }
     
     @Override
     public MapperResult incrementUsageByWhereQuotaNotEqualZero(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = `usage` + 1, gmt_modified = ? WHERE group_id = ? AND `usage` < quota AND quota != 0";
+        String sql = "UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ? AND usage < quota AND quota != 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
     
     @Override
     public MapperResult incrementUsageByWhere(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = `usage` + 1, gmt_modified = ? WHERE group_id = ?";
+        String sql = "UPDATE group_capacity SET usage = usage + 1, gmt_modified = ? WHERE group_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
     
     @Override
     public MapperResult decrementUsageByWhere(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = `usage` - 1, gmt_modified = ? WHERE group_id = ? AND `usage` > 0";
+        String sql = "UPDATE group_capacity SET usage = usage - 1, gmt_modified = ? WHERE group_id = ? AND usage > 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
     
     @Override
     public MapperResult updateUsage(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info), gmt_modified = ? WHERE group_id = ?";
+        String sql = "UPDATE group_capacity SET usage = (SELECT count(*) FROM config_info), gmt_modified = ? WHERE group_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.GROUP_ID)));
     }
     
     @Override
     public MapperResult updateUsageByWhere(MapperContext context) {
-        String sql = "UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE group_id=? AND "
+        String sql = "UPDATE group_capacity SET usage = (SELECT count(*) FROM config_info WHERE group_id=? AND "
                 + " tenant_id = '" + NamespaceUtil.getNamespaceDefaultId() + "'),"
                 + " gmt_modified = ? WHERE group_id= ?";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.GROUP_ID),

--- a/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dm/TenantCapacityMapperByDaMeng.java
+++ b/nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dm/TenantCapacityMapperByDaMeng.java
@@ -37,44 +37,44 @@ public class TenantCapacityMapperByDaMeng extends AbstractMapperByDaMeng impleme
     
     @Override
     public MapperResult select(MapperContext context) {
-        String sql = "select id,tenant_id,quota,`usage`,max_size,max_aggr_count,max_aggr_size "
+        String sql = "select id,tenant_id,quota,usage,max_size,max_aggr_count,max_aggr_size "
                 + " from tenant_capacity where tenant_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
     public MapperResult incrementUsageWithDefaultQuotaLimit(MapperContext context) {
-        String sql = "update tenant_capacity set `usage` = `usage` + 1, gmt_modified = ? "
-                + " where tenant_id = ? and `usage` < ? and quota = 0";
+        String sql = "update tenant_capacity set usage = usage + 1, gmt_modified = ? "
+                + " where tenant_id = ? and usage < ? and quota = 0";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.TENANT_ID), context.getWhereParameter(FieldConstant.USAGE)));
     }
     
     @Override
     public MapperResult incrementUsageWithQuotaLimit(MapperContext context) {
-        String sql = "update tenant_capacity set `usage` = `usage` + 1, gmt_modified = ? "
-                + " where tenant_id = ? and `usage` < quota and quota != 0";
+        String sql = "update tenant_capacity set usage = usage + 1, gmt_modified = ? "
+                + " where tenant_id = ? and usage < quota and quota != 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
     public MapperResult incrementUsage(MapperContext context) {
-        String sql = "UPDATE tenant_capacity SET `usage` = `usage` + 1, gmt_modified = ? WHERE tenant_id = ?";
+        String sql = "UPDATE tenant_capacity SET usage = usage + 1, gmt_modified = ? WHERE tenant_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
     public MapperResult decrementUsage(MapperContext context) {
-        String sql = "UPDATE tenant_capacity SET `usage` = `usage` - 1, gmt_modified = ? WHERE tenant_id = ? AND `usage` > 0";
+        String sql = "UPDATE tenant_capacity SET usage = usage - 1, gmt_modified = ? WHERE tenant_id = ? AND usage > 0";
         return new MapperResult(sql, CollectionUtils.list(context.getUpdateParameter(FieldConstant.GMT_MODIFIED),
                 context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
     public MapperResult correctUsage(MapperContext context) {
-        String sql = "UPDATE tenant_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE tenant_id = ?), "
+        String sql = "UPDATE tenant_capacity SET usage = (SELECT count(*) FROM config_info WHERE tenant_id = ?), "
                         + "gmt_modified = ? WHERE tenant_id = ?";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID),
                 context.getUpdateParameter(FieldConstant.GMT_MODIFIED), context.getWhereParameter(FieldConstant.TENANT_ID)));
@@ -100,7 +100,7 @@ public class TenantCapacityMapperByDaMeng extends AbstractMapperByDaMeng impleme
         paramList.add(context.getWhereParameter(FieldConstant.TENANT_ID));
         
         return new MapperResult(
-                "INSERT INTO tenant_capacity (tenant_id, quota, `usage`, max_size, max_aggr_count, max_aggr_size, "
+                "INSERT INTO tenant_capacity (tenant_id, quota, usage, max_size, max_aggr_count, max_aggr_size, "
                         + "gmt_create, gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE tenant_id=?",
                 paramList);
     }


### PR DESCRIPTION
## Problem

`usage` is a reserved word in MySQL, so the MySQL capacity mappers have to quote it with backticks. The nacos source says so itself — from `GroupCapacityMapperByMysql` (2.5.x):

> Note: Since usage field is a MySQL keyword, SQL needs to use `usage` to represent it

```sql
SELECT id, quota, `usage`, max_size, ... FROM group_capacity WHERE group_id = ?
```

The DM mappers inherit that SQL, but Dameng (DM) does **not** support backtick-quoted identifiers. When Nacos runs on Dameng and the capacity tables are touched — e.g. `CapacityManagementAspect` firing on config publish — the driver rejects the SQL:

```
BadSqlGrammarException: ... syntax error near 'usage'
```

This makes capacity management unusable on Dameng.

## Fix

Remove the backticks around `usage` in the DM mappers only.

| File | Changed SQL statements | Backticks removed |
|---|---|---|
| `GroupCapacityMapperByDaMeng.java` | 9 | 32 |
| `TenantCapacityMapperByDaMeng.java` | 9 | 28 |
| **Total** | **18** | **60** |

Nothing else is touched: SQL structure, parameter lists, join conditions and business logic are byte-for-byte identical to the current implementation. The DM mappers are only loaded via SPI when `spring.sql.init.platform=dm`, so MySQL and other databases are unaffected.

The two pagination methods (`selectGroupInfoBySize`, `getCapacityList4CorrectUsage`) are left alone — they already go through `DatabaseDialect.getLimitTopSqlWithMark()` in the base module and contain no backticks.

## Note on affected versions

This was introduced when the capacity SQL moved into the MySQL mappers. For reference:

- nacos **2.4.3**: `GroupCapacityMapperByMysql` has no backtick SQL — not affected
- nacos **2.5.x**: 9 + 9 backtick statements — affected (verified on 2.5.3)
- nacos **3.2.x** (this branch): same backtick SQL present in the DM mappers — affected

## Verification

- Build passes: `mvn clean install -pl nacos-datasource-plugin-ext/nacos-dm-datasource-plugin-ext -am -DskipTests`
- Verified on Nacos 3.2.4 + DM8 standalone:
  - Nacos starts, SPI loads the DM mappers
  - Publishing a config triggers `getGroupCapacity` / `getTenantCapacity` with no `BadSqlGrammarException`
  - Config read/write and service registration/discovery work normally

## Checklist

- [x] Only the two DM capacity mapper files are changed
- [x] No SPI registration file touched (no new class is introduced)
- [x] Pagination still goes through `DatabaseDialect.getLimitTopSqlWithMark()`, not hardcoded `LIMIT`
- [x] Function mapping still goes through `DatabaseDialect.getFunction()`
